### PR TITLE
Destroy surface handle on shutdown

### DIFF
--- a/utils/util.hpp
+++ b/utils/util.hpp
@@ -170,6 +170,7 @@ struct sample_info {
     PFN_vkGetPhysicalDeviceSurfacePresentModesKHR fpGetPhysicalDeviceSurfacePresentModesKHR;
     PFN_vkCreateSwapchainKHR fpCreateSwapchainKHR;
     PFN_vkDestroySwapchainKHR fpDestroySwapchainKHR;
+    PFN_vkDestroySurfaceKHR fpDestroySurfaceKHR;
     PFN_vkGetSwapchainImagesKHR fpGetSwapchainImagesKHR;
     PFN_vkAcquireNextImageKHR fpAcquireNextImageKHR;
     PFN_vkQueuePresentKHR fpQueuePresentKHR;

--- a/utils/util_init.cpp
+++ b/utils/util_init.cpp
@@ -491,6 +491,7 @@ void init_window(struct sample_info &info)
 void destroy_window(struct sample_info &info)
 {
     DestroyWindow(info.window);
+    info.fpDestroySurfaceKHR(info.inst, info.surface, NULL);
 }
 #else
 void init_window(struct sample_info &info)
@@ -660,6 +661,7 @@ void init_swapchain_extension(struct sample_info &info)
     GET_INSTANCE_PROC_ADDR(info.inst, GetPhysicalDeviceSurfaceCapabilitiesKHR);
     GET_INSTANCE_PROC_ADDR(info.inst, GetPhysicalDeviceSurfaceFormatsKHR);
     GET_INSTANCE_PROC_ADDR(info.inst, GetPhysicalDeviceSurfacePresentModesKHR);
+    GET_INSTANCE_PROC_ADDR(info.inst, DestroySurfaceKHR);
     GET_DEVICE_PROC_ADDR(info.device, CreateSwapchainKHR);
     GET_DEVICE_PROC_ADDR(info.device, DestroySwapchainKHR);
     GET_DEVICE_PROC_ADDR(info.device, GetSwapchainImagesKHR);


### PR DESCRIPTION
Pretty much as it says, this wasn't happening and technically the handle was leaking.
