### PR TITLE
prepare for android porting

### DIFF
--- a/src/vk0.10-allocdescriptorsets.cpp
+++ b/src/vk0.10-allocdescriptorsets.cpp
@@ -95,4 +95,5 @@ int main(int argc, char **argv)
     destroy_descriptor_and_pipeline_layouts(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-copyblitimage.cpp
+++ b/src/vk0.10-copyblitimage.cpp
@@ -286,4 +286,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-descriptor_pipeline_layouts.cpp
+++ b/src/vk0.10-descriptor_pipeline_layouts.cpp
@@ -87,5 +87,6 @@ int main(int argc, char **argv)
     vkDestroyPipelineLayout(info.device, info.pipeline_layout, NULL);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }
 

--- a/src/vk0.10-drawcube.cpp
+++ b/src/vk0.10-drawcube.cpp
@@ -252,4 +252,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-drawsubpasses.cpp
+++ b/src/vk0.10-drawsubpasses.cpp
@@ -692,4 +692,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-drawtexturedcube.cpp
+++ b/src/vk0.10-drawtexturedcube.cpp
@@ -256,4 +256,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-dynamicuniform.cpp
+++ b/src/vk0.10-dynamicuniform.cpp
@@ -408,4 +408,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-immutable_sampler.cpp
+++ b/src/vk0.10-immutable_sampler.cpp
@@ -309,4 +309,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-initcommandbuffer.cpp
+++ b/src/vk0.10-initcommandbuffer.cpp
@@ -81,4 +81,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-initframebuffers.cpp
+++ b/src/vk0.10-initframebuffers.cpp
@@ -98,4 +98,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-initpipeline.cpp
+++ b/src/vk0.10-initpipeline.cpp
@@ -262,6 +262,6 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
-
+    return 0;
 }
 

--- a/src/vk0.10-initrenderpass.cpp
+++ b/src/vk0.10-initrenderpass.cpp
@@ -123,5 +123,6 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }
 

--- a/src/vk0.10-initshaders.cpp
+++ b/src/vk0.10-initshaders.cpp
@@ -131,4 +131,5 @@ int main(int argc, char **argv)
     vkDestroyShaderModule(info.device, info.shaderStages[1].module, NULL);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-inittexture.cpp
+++ b/src/vk0.10-inittexture.cpp
@@ -305,4 +305,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-multiple_sets.cpp
+++ b/src/vk0.10-multiple_sets.cpp
@@ -371,4 +371,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-multithreadcmdbuf.cpp
+++ b/src/vk0.10-multithreadcmdbuf.cpp
@@ -317,6 +317,7 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }
 
 static void * per_thread_code(void *arg)

--- a/src/vk0.10-occlusion_query.cpp
+++ b/src/vk0.10-occlusion_query.cpp
@@ -381,4 +381,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-pipeline_cache.cpp
+++ b/src/vk0.10-pipeline_cache.cpp
@@ -367,4 +367,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-pipeline_derivative.cpp
+++ b/src/vk0.10-pipeline_derivative.cpp
@@ -381,4 +381,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-push_constants.cpp
+++ b/src/vk0.10-push_constants.cpp
@@ -307,4 +307,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-secondarycmd.cpp
+++ b/src/vk0.10-secondarycmd.cpp
@@ -382,4 +382,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-separate_image_sampler.cpp
+++ b/src/vk0.10-separate_image_sampler.cpp
@@ -342,4 +342,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-spirv_assembly.cpp
+++ b/src/vk0.10-spirv_assembly.cpp
@@ -357,4 +357,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-spirv_specialization.cpp
+++ b/src/vk0.10-spirv_specialization.cpp
@@ -421,4 +421,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-template.cpp
+++ b/src/vk0.10-template.cpp
@@ -181,4 +181,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-texelbuffer.cpp
+++ b/src/vk0.10-texelbuffer.cpp
@@ -339,4 +339,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-uniformbuffer.cpp
+++ b/src/vk0.10-uniformbuffer.cpp
@@ -109,4 +109,5 @@ int main(int argc, char **argv)
     vkFreeMemory(info.device, info.uniform_data.mem, NULL);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }

--- a/src/vk0.10-vertexbuffer.cpp
+++ b/src/vk0.10-vertexbuffer.cpp
@@ -176,4 +176,5 @@ int main(int argc, char **argv)
     destroy_window(info);
     destroy_device(info);
     destroy_instance(info);
+    return 0;
 }


### PR DESCRIPTION
this is just to add several "return 0;" to some of the sample's main() functions: on android build, warning was treated as errors, hence prevent from compiling. Maybe could take care of it before porting happens so in future android porting, only android related changes are in that checkin.  There is no functional change.

thank you for your consideration and review
