### PR TITLE
fixed typo for enabledLayerCount

### DIFF
--- a/API-Samples/device/device.cpp
+++ b/API-Samples/device/device.cpp
@@ -78,7 +78,7 @@ int sample_main()
     device_info.pQueueCreateInfos = &queue_info;
     device_info.enabledExtensionCount = 0;
     device_info.ppEnabledExtensionNames = NULL;
-    device_info.enabledExtensionCount = 0;
+    device_info.enabledLayerCount = 0;
     device_info.ppEnabledLayerNames = NULL;
     device_info.pEnabledFeatures = NULL;
 


### PR DESCRIPTION
there was a typo for the layerCount in device.cpp; corresponding code in init_device() is correct.
please kindly have a look, thanks
