### PR TITLE
some platform crashes when having a semaphore pointer not NULL but semaphore count is 0 

### DIFF
--- a/API-Samples/drawcube/drawcube.cpp
+++ b/API-Samples/drawcube/drawcube.cpp
@@ -199,7 +199,7 @@ int sample_main()
     VkSubmitInfo submit_info[1] = {};
     submit_info[0].pNext = NULL;
     submit_info[0].sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    submit_info[0].waitSemaphoreCount = 0;
+    submit_info[0].waitSemaphoreCount = 1;
     submit_info[0].pWaitSemaphores = &presentCompleteSemaphore;
     submit_info[0].pWaitDstStageMask = &pipe_stage_flags;
     submit_info[0].commandBufferCount = 1;

--- a/API-Samples/drawsubpasses/drawsubpasses.cpp
+++ b/API-Samples/drawsubpasses/drawsubpasses.cpp
@@ -630,7 +630,7 @@ int sample_main()
     VkSubmitInfo submit_info[1] = {};
     submit_info[0].pNext = NULL;
     submit_info[0].sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    submit_info[0].waitSemaphoreCount = 0;
+    submit_info[0].waitSemaphoreCount = 1;
     submit_info[0].pWaitSemaphores = &presentCompleteSemaphore;
     submit_info[0].commandBufferCount = 1;
     submit_info[0].pCommandBuffers = cmd_bufs;

--- a/API-Samples/occlusion_query/occlusion_query.cpp
+++ b/API-Samples/occlusion_query/occlusion_query.cpp
@@ -294,7 +294,7 @@ int sample_main()
     VkSubmitInfo submit_info[1] = {};
     submit_info[0].pNext = NULL;
     submit_info[0].sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    submit_info[0].waitSemaphoreCount = 0;
+    submit_info[0].waitSemaphoreCount = 1;
     submit_info[0].pWaitSemaphores = &presentCompleteSemaphore;
     submit_info[0].commandBufferCount = 1;
     submit_info[0].pCommandBuffers = cmd_bufs;


### PR DESCRIPTION
This is to workaround Android Shield driver issue:
it crashes when count = 0, but semaphore pointing to something.