### PR TITLE
Layer-Samples: Don't hard-code "build" directory.

### DIFF
--- a/Layer-Samples/Overlay/CMakeLists.txt
+++ b/Layer-Samples/Overlay/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(VKLayer_overlay layer_utils)
 set_target_properties(VKLayer_overlay PROPERTIES CXX_FLAGS "-Wno-unused-function")
 
 include_directories(
-        "${CMAKE_SOURCE_DIR}/build/layers"
+        "${CMAKE_BINARY_DIR}/layers"
         "${CMAKE_SOURCE_DIR}/layers"
         "${CMAKE_SOURCE_DIR}/loader"
         "${UTILDIR}/stb"


### PR DESCRIPTION
CMake provides the CMAKE_BINARY_DIR}/layers variable, which allows somebody to
call it "build" or "dbuild" or "_out64", etc.  This CMakeLists.txt file
hard-coded it to "${CMAKE_SOURCE_DIR}/build" instead (meaning it has to be
"build", or the user can use a symlink from "build" to <whatever>.  This fix
avoids hard-coding the value.