### PR TITLE
Hologram: Fix last 7 warnings on VS2015

### DIFF
--- a/Sample-Programs/Hologram/Hologram.cpp
+++ b/Sample-Programs/Hologram/Hologram.cpp
@@ -75,7 +75,8 @@ void Hologram::init_workers()
         worker_count = 1;
     }
 
-    const int object_per_worker = sim_.objects().size() / worker_count;
+    assert(sim_.objects().size() <= INT32_MAX);
+    const int object_per_worker = static_cast<int>(sim_.objects().size() / worker_count);
     int object_begin = 0, object_end = 0;
 
     workers_.reserve(worker_count);
@@ -84,7 +85,7 @@ void Hologram::init_workers()
         if (i < worker_count - 1)
             object_end += object_per_worker;
         else
-            object_end = sim_.objects().size();
+            object_end = static_cast<int>(sim_.objects().size());
 
         Worker *worker = new Worker(*this, i, object_begin, object_end);
         workers_.emplace_back(std::unique_ptr<Worker>(worker));
@@ -472,7 +473,8 @@ void Hologram::create_buffers()
         object_data_size += alignment - (object_data_size % alignment);
 
     // update simulation
-    sim_.set_frame_data_size(object_data_size);
+    assert(object_data_size <= UINT32_MAX);
+    sim_.set_frame_data_size(static_cast<uint32_t>(object_data_size));
 
     VkBufferCreateInfo buf_info = {};
     buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -526,11 +528,12 @@ void Hologram::create_descriptor_sets()
 {
     VkDescriptorPoolSize desc_pool_size = {};
     desc_pool_size.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
-    desc_pool_size.descriptorCount = frame_data_.size();
+    assert(frame_data_.size() <= UINT32_MAX);
+    desc_pool_size.descriptorCount = static_cast<uint32_t>(frame_data_.size());
 
     VkDescriptorPoolCreateInfo desc_pool_info = {};
     desc_pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    desc_pool_info.maxSets = frame_data_.size();
+    desc_pool_info.maxSets = static_cast<uint32_t>(frame_data_.size());
     desc_pool_info.poolSizeCount = 1;
     desc_pool_info.pPoolSizes = &desc_pool_size;
 

--- a/Sample-Programs/Hologram/Meshes.cpp
+++ b/Sample-Programs/Hologram/Meshes.cpp
@@ -116,7 +116,7 @@ public:
 
     uint32_t vertex_count() const
     {
-        return positions_.size();
+        return static_cast<uint32_t>(positions_.size());
     }
 
     VkDeviceSize vertex_buffer_size() const
@@ -142,7 +142,7 @@ public:
 
     uint32_t index_count() const
     {
-        return faces_.size() * 3;
+        return static_cast<uint32_t>(faces_.size() * 3);
     }
 
     VkDeviceSize index_buffer_size() const


### PR DESCRIPTION
Most of these warnings are from not explicitly casting size_t, and uint32_t to int. I have added static_cast, and some asserts to check if the values can fit inside the types they are cast to.