### PR TITLE
utils: Fix 3 signed/unsigned mismatch warnings on VS2015

### DIFF
--- a/API-Samples/utils/util.cpp
+++ b/API-Samples/utils/util.cpp
@@ -493,7 +493,7 @@ void process_command_line_args(struct sample_info &info, int argc,
 
 void write_ppm(struct sample_info &info, const char *basename) {
     string filename;
-    uint32_t x, y;
+    int x, y;
     VkResult res;
 
     VkImageCreateInfo image_create_info = {};


### PR DESCRIPTION
Changes x and y from uint32_t to int to match type of width and
height. I considered changing width and height in the sample_info struct
to uint32_t but there was quite a bit of code that would need re-work and
verification.