### PR TITLE
Hologram: Set locations on varyings

### DIFF
--- a/Sample-Programs/Hologram/Hologram.frag
+++ b/Sample-Programs/Hologram/Hologram.frag
@@ -2,8 +2,8 @@
 
 precision highp float;
 
-in vec3 color;
-in float alpha;
+layout(location = 0) in vec3 color;
+layout(location = 1) in float alpha;
 
 layout(location = 0) out vec4 fragcolor;
 

--- a/Sample-Programs/Hologram/Hologram.push_constant.vert
+++ b/Sample-Programs/Hologram/Hologram.push_constant.vert
@@ -10,7 +10,7 @@ layout(std140, push_constant) uniform param_block {
 	mat4 view_projection;
 } params;
 
-out vec3 color;
+layout(location = 0) out vec3 color;
 
 void main()
 {

--- a/Sample-Programs/Hologram/Hologram.vert
+++ b/Sample-Programs/Hologram/Hologram.vert
@@ -11,8 +11,8 @@ layout(std140, set = 0, binding = 0) readonly buffer param_block {
 	float alpha;
 } params;
 
-out vec3 color;
-out float alpha;
+layout(location = 0) out vec3 color;
+layout(location = 1) out float alpha;
 
 void main()
 {


### PR DESCRIPTION
Vulkan requires that locations be set on all inputs and outputs.  This gets the demo working on the Intel Linux Vulkan driver