### PR TITLE
Android build fix on Windows.

### DIFF
--- a/API-Samples/android/project_template/build.gradle
+++ b/API-Samples/android/project_template/build.gradle
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 apply plugin: 'com.android.model.application'
 
 Properties properties = new Properties()
@@ -21,6 +23,11 @@ def shadercLibPath = file(ndkDir).absolutePath + "/sources/third_party/shaderc"
 def vulkanWrapperPath = file(project.rootProject.projectDir).absolutePath + "/vulkan_wrapper"
 
 def stlType = "c++_shared"
+
+def ndkbuild = "ndk-build"
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    ndkbuild = "ndk-build.cmd"
+}
 
 model {
     repositories {
@@ -119,7 +126,7 @@ model {
 
 task build_shaderc(type:Exec) {
     workingDir "${shadercLibPath}"
-    commandLine "${ndkDir}/ndk-build", "NDK_PROJECT_PATH=.", "APP_BUILD_SCRIPT=Android.mk", "APP_STL:=${stlType}", "APP_ABI=@FLAVOR@", "libshaderc_combined", "-j16"
+    commandLine "${ndkDir}/${ndkbuild}", "NDK_PROJECT_PATH=.", "APP_BUILD_SCRIPT=Android.mk", "APP_STL:=${stlType}", "APP_ABI=@FLAVOR@", "libshaderc_combined", "-j16"
 }
 
 tasks.whenTaskAdded { task ->

--- a/API-Samples/android/settings.gradle
+++ b/API-Samples/android/settings.gradle
@@ -16,7 +16,7 @@
 Properties properties = new Properties()
 properties.load(file('local.properties').newDataInputStream())
 def ndkDir = properties.getProperty('ndk.dir')
-def layerProjRoot = file(ndkDir).absolutePath + file('/sources/third_party/vulkan/src/build-android/generated/gradle-build')
+def layerProjRoot = file(ndkDir).absolutePath + '/sources/third_party/vulkan/src/build-android/generated/gradle-build'
 String[] layers = ['threading',
                    'parameter_validation',
                    'object_tracker',

--- a/API-Samples/android/settings.gradle.in
+++ b/API-Samples/android/settings.gradle.in
@@ -16,7 +16,7 @@
 Properties properties = new Properties()
 properties.load(file('local.properties').newDataInputStream())
 def ndkDir = properties.getProperty('ndk.dir')
-def layerProjRoot = file(ndkDir).absolutePath + file('/sources/third_party/vulkan/src/build-android/generated/gradle-build')
+def layerProjRoot = file(ndkDir).absolutePath + '/sources/third_party/vulkan/src/build-android/generated/gradle-build'
 String[] layers = ['threading',
                    'parameter_validation',
                    'object_tracker',


### PR DESCRIPTION
- Invoke ndk-build.cmd on Windows.
- Change validation layer path to work on Windows.

Change-Id: I24236bbcf8f6b2e4a1307a6d7ebeae695b1592e1
Tested: on OSX and on Windows.