### PR TITLE
fix possibly UB when iterating memory types

### DIFF
--- a/API-Samples/utils/util.cpp
+++ b/API-Samples/utils/util.cpp
@@ -106,7 +106,7 @@ bool memory_type_from_properties(struct sample_info &info, uint32_t typeBits,
                                  VkFlags requirements_mask,
                                  uint32_t *typeIndex) {
     // Search memtypes to find first index with those properties
-    for (uint32_t i = 0; i < 32; i++) {
+    for (uint32_t i = 0; i < info.memory_properties.memoryTypeCount; i++) {
         if ((typeBits & 1) == 1) {
             // Type is available, does it match user properties?
             if ((info.memory_properties.memoryTypes[i].propertyFlags &

--- a/demos/cube.c
+++ b/demos/cube.c
@@ -439,7 +439,7 @@ static bool memory_type_from_properties(struct demo *demo, uint32_t typeBits,
                                         VkFlags requirements_mask,
                                         uint32_t *typeIndex) {
     // Search memtypes to find first index with those properties
-    for (uint32_t i = 0; i < 32; i++) {
+    for (uint32_t i = 0; i < VK_MAX_MEMORY_TYPES; i++) {
         if ((typeBits & 1) == 1) {
             // Type is available, does it match user properties?
             if ((demo->memory_properties.memoryTypes[i].propertyFlags &

--- a/demos/tri.c
+++ b/demos/tri.c
@@ -279,7 +279,7 @@ static bool memory_type_from_properties(struct demo *demo, uint32_t typeBits,
                                         VkFlags requirements_mask,
                                         uint32_t *typeIndex) {
     // Search memtypes to find first index with those properties
-    for (uint32_t i = 0; i < 32; i++) {
+    for (uint32_t i = 0; i < VK_MAX_MEMORY_TYPES; i++) {
         if ((typeBits & 1) == 1) {
             // Type is available, does it match user properties?
             if ((demo->memory_properties.memoryTypes[i].propertyFlags &


### PR DESCRIPTION
Note that on a reliable implementation, the UB should not trigger as such implementation would return a bitfield (after calling vkGetBufferMemoryRequirements) with MSBs over the number of available memory types cleared.

But if the implementation is buggy and some MSBs over the number of available memory types are set, the UB would trigger in the application. I'm not sure how you wish to handle such situation.

In any case with this patch, the loop will not iterate more than needed (so this is more of an optimization than anything else).

It's up to you, but if you decide to reject the patch, I suggest using VK_MAX_MEMORY_TYPES instead of 32.