### PR TITLE
Add some missing markdown quotes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ make
 ```
 ## Android:
 
+```
 $ cmake -DANDROID=ON -DANDROID_ABI=[armeabi-v7a|arm64-v8a| x86|x86_64|all(default)]
+```
 And import VulkanSamples/API-Samples/android/build.gradle in Android Studio.
 
 ## Windows System Requirements
@@ -81,6 +83,7 @@ cd VulkanSamples  # cd to the root of the VulkanSamples git repository
 mkdir build
 cd build
 cmake -G "Visual Studio 12 Win64" ..
+```
 
 At this point, you can use Windows Explorer to launch Visual Studio by double-clicking on the "VULKAN.sln" file in the \buil
 d folder.  


### PR DESCRIPTION
I'm usually not a stickler for pedantic markup correctness, but these
two resulted in some legitimately confusing/wrong rendered output in the
HTML on github.

The one in the Android section would cause the prose to be rendered on
the same line after the command which is somewhat annoying.

The on in the Windows section was missing a "close quote" which caused
havok for the rest of the document.