### PR TITLE
fix ppm loader swapped width & height

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -1032,7 +1032,7 @@ bool loadTexture(const char *filename, uint8_t *rgba_data,
         return false;
     }
     while(strncmp(cPtr++, "\n", 1));
-    sscanf(cPtr, "%u %u", height, width);
+    sscanf(cPtr, "%u %u", width, height);
     if (rgba_data == NULL) {
         return true;
     }
@@ -1075,7 +1075,7 @@ bool loadTexture(const char *filename, uint8_t *rgba_data,
         }
     } while (!strncmp(header, "#", 1));
 
-    sscanf(header, "%u %u", height, width);
+    sscanf(header, "%u %u", width, height);
     if (rgba_data == NULL) {
         fclose(fPtr);
         return true;


### PR DESCRIPTION
PPM format says that width comes before height (in ASCII). This patch is basically a NOP in current demos state since all .ppm files are square (width == height). The bug would trigger only if a non-square .ppm would be introduced.