### PR TITLE
samples: Fix 4x4 matrix layout

### DIFF
--- a/API-Samples/07-init_uniform_buffer/07-init_uniform_buffer.cpp
+++ b/API-Samples/07-init_uniform_buffer/07-init_uniform_buffer.cpp
@@ -48,9 +48,14 @@ int sample_main(int argc, char *argv[]) {
                             glm::vec3(0, -1, 0)     // Head is up (set to 0,-1,0 to look upside-down)
                             );
     info.Model = glm::mat4(1.0f);
-    // Vulkan clip space has inverted Y and half Z.
-    info.Clip = glm::mat4(1.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.5f, 0.0f, 0.0f, 0.0f, 0.5f, 1.0f);
 
+    // Vulkan clip space has inverted Y and half Z.
+    // clang-format off
+    info.Clip = glm::mat4(1.0f, 0.0f, 0.0f, 0.0f,
+                          0.0f,-1.0f, 0.0f, 0.0f,
+                          0.0f, 0.0f, 0.5f, 0.0f,
+                          0.0f, 0.0f, 0.5f, 1.0f);
+    // clang-format on
     info.MVP = info.Clip * info.Projection * info.View * info.Model;
 
     /* VULKAN_KEY_START */


### PR DESCRIPTION
Clang-format placed the matrix on a single line,
which makes the matrix hard to read.

Change-Id: If0cf58c77cea711f1c07fcf0d06a6fd6b0f1eb63