### PR TITLE
samples: Fix 4x4 matrix layout

### DIFF
--- a/API-Samples/dynamic_uniform/dynamic_uniform.cpp
+++ b/API-Samples/dynamic_uniform/dynamic_uniform.cpp
@@ -109,8 +109,12 @@ int sample_main(int argc, char *argv[]) {
                             );
     info.Model = glm::mat4(1.0f);
     // Vulkan clip space has inverted Y and half Z.
-    info.Clip = glm::mat4(1.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.5f, 0.0f, 0.0f, 0.0f, 0.5f, 1.0f);
-
+    // clang-format off
+    info.Clip = glm::mat4(1.0f, 0.0f, 0.0f, 0.0f,
+                          0.0f,-1.0f, 0.0f, 0.0f,
+                          0.0f, 0.0f, 0.5f, 0.0f,
+                          0.0f, 0.0f, 0.5f, 1.0f);
+    // clang-format on
     info.MVP = info.Clip * info.Projection * info.View * info.Model;
     /* VULKAN_KEY_START */
     info.Model = glm::translate(info.Model, glm::vec3(-1.5, 1.5, -1.5));


### PR DESCRIPTION
Another instance where clang-format
 placed a 4x4 matrix on a single line.
Change-Id: I50711d079c84affcb81cffded9d2a1753cba0c5d