### PR TITLE
build: Fix CMake warnings in SDK build

### DIFF
--- a/Layer-Samples/Overlay/CMakeLists.txt
+++ b/Layer-Samples/Overlay/CMakeLists.txt
@@ -49,7 +49,7 @@ add_custom_command(OUTPUT ${SHADER_DIR}/${SFILE}-frag.spv
 message(STATUS "Shader dir: ${SHADER_DIR}")
 message(STATUS "Cxxflags: ${CMAKE_CXX_FLAGS}")
 
-if (EXISTS "${CMAKE_SOURCE_DIR}/layers")
+if(NOT SDK_INCLUDE_PATH)
     set(LAYERS_LOC ${CMAKE_SOURCE_DIR})
     set(LAYER_UTILS_LIB VkLayer_utils)
 else()
@@ -82,7 +82,9 @@ else()
 endif()
 
 target_link_libraries(VKLayer_overlay ${LAYER_UTILS_LIB})
-add_dependencies(VKLayer_overlay generate_helper_files VkLayer_utils)
+if(NOT SDK_INCLUDE_PATH)
+    add_dependencies(VKLayer_overlay generate_helper_files VkLayer_utils)
+endif()
 set_target_properties(VKLayer_overlay PROPERTIES CXX_FLAGS "-Wno-unused-function")
 
 if(SDK_INCLUDE_PATH)


### PR DESCRIPTION
In the Overlay project, don't specify a build dependency
on layers in an SDK build since the layers are already built.
Also, use a consistent test to distinguish between a Repo build
and a SDK build.

Change-Id: I6d32244ee05598e56ab5e12f61f4620c12156529