### PR TITLE
Android Fix: add texture file as asset to sample memory_barrier

### DIFF
--- a/API-Samples/04-init_command_buffer/04-init_command_buffer.cpp
+++ b/API-Samples/04-init_command_buffer/04-init_command_buffer.cpp
@@ -32,7 +32,8 @@ int sample_main(int argc, char *argv[]) {
     VkResult U_ASSERT_ONLY res;
     struct sample_info info = {};
     char sample_title[] = "Command Buffer Sample";
-
+    
+    init_global_layer_properties(info);
     init_instance(info, sample_title);
     init_enumerate_device(info);
     init_device(info);

--- a/API-Samples/CMakeLists.txt
+++ b/API-Samples/CMakeLists.txt
@@ -104,7 +104,7 @@ function(sampleWithSingleFile)
 
             # Include resource files.
             set (SAMPLE_WITH_RESOURCES
-             draw_textured_cube init_texture immutable_sampler multiple_sets pipeline_cache
+             draw_textured_cube init_texture immutable_sampler memory_barriers multiple_sets pipeline_cache
              pipeline_derivative secondary_command_buffer separate_image_sampler spirv_assembly
              spirv_specialization template)
             if (";${SAMPLE_WITH_RESOURCES};" MATCHES ";${SAMPLE_NAME};")

--- a/API-Samples/utils/util.cpp
+++ b/API-Samples/utils/util.cpp
@@ -830,9 +830,11 @@ void Android_handle_cmd(android_app *app, int32_t cmd) {
         case APP_CMD_INIT_WINDOW:
             // The window is being shown, get it ready.
             sample_main(0, nullptr);
-            LOGI("=============================");
-            LOGI("The sample ran successfully!!");
-            LOGI("=============================");
+            LOGI("\n");
+            LOGI("=================================================");
+            LOGI("          The sample ran successfully!!");
+            LOGI("=================================================");
+            LOGI("\n");
             break;
         case APP_CMD_TERM_WINDOW:
             // The window is being hidden or closed, clean it up.

--- a/API-Samples/utils/util.hpp
+++ b/API-Samples/utils/util.hpp
@@ -278,10 +278,10 @@ int sample_main(int argc, char *argv[]);
 
 #ifdef __ANDROID__
 // Android specific definitions & helpers.
-#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "threaded_app", __VA_ARGS__))
-#define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, "threaded_app", __VA_ARGS__))
+#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "VK-SAMPLE", __VA_ARGS__))
+#define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, "VK-SAMPLE", __VA_ARGS__))
 // Replace printf to logcat output.
-#define printf(...) __android_log_print(ANDROID_LOG_DEBUG, "TAG", __VA_ARGS__);
+#define printf(...) __android_log_print(ANDROID_LOG_DEBUG, "VK-SAMPLE", __VA_ARGS__);
 
 bool Android_process_command();
 ANativeWindow* AndroidGetApplicationWindow();


### PR DESCRIPTION
API-Sample for Android fixes:
  1) sample memory_barrier actually need texture, gradle scripts forgot including texture file lunarg.ppm
  2) init_command_buffer missed the vulkan wrapper init, adding it back

@cnorthrop @bbilodeau   @karl-lunarg May you please take a quick look?  thank you so much!