### PR TITLE
Fixed VkResult const in tutorial pages

### DIFF
--- a/API-Samples/Tutorial/markdown/01-init_instance.md
+++ b/API-Samples/Tutorial/markdown/01-init_instance.md
@@ -209,7 +209,7 @@ Once the structures are populated, the sample app creates the instance:
 
 In the code above, the application makes a quick check for the mostly likely error
 and reports it, or some other error, according to the result.
-Note that a success (`VK_ERROR_SUCCESS`) has a value of zero,
+Note that a success (`VK_SUCCESS`) has a value of zero,
 so many applications take the shortcut of interpreting
 a non-zero result as an error, which is the case here.
 


### PR DESCRIPTION
Since this is the first page of tutorials it should correctly mention that VK_SUCCESS is zero as there is no VK_ERROR_SUCCESS in the entire repo

Small type but prevent someone from doing a `if (result == VK_ERROR_SUCCESS) {}` and unable to figure out why it keeps failing check