### PR TITLE
For Android Build:

### DIFF
--- a/API-Samples/android/project_template/build.gradle
+++ b/API-Samples/android/project_template/build.gradle
@@ -14,9 +14,20 @@
 
 apply plugin: 'com.android.application'
 
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
-def ndkDir = properties.getProperty('ndk.dir')
+def ndkDir
+if (project.rootProject.file('local.properties').exists()) {
+    Properties properties = new Properties()
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+    ndkDir = properties.getProperty('ndk.dir')
+}
+if (!ndkDir) {
+    ndkDir=System.getenv("ANDROID_NDK_HOME")
+}
+
+if(!ndkDir || ndkDir.empty) {
+   throw new GradleException('Environment Variable ANDROID_NDK_HOME for NDK path need to be setup')
+}
+
 
 def stlType = 'gnustl_static'
 


### PR DESCRIPTION
check for ANDROID_NDK_HOME if local.properties is not present. So NDK directory setting checking sequence ( priority ) is:
1. local.properties file ( Android Studio IDE using it )
1. environment variable ANDROID_NDK_HOME settings

if none of the above is set, fail the build

@cnorthrop @bbilodeau