### PR TITLE
build: Remove app_dummy() From Hologram for Android NDK r15 and above

### DIFF
--- a/Sample-Programs/Hologram/ShellAndroid.cpp
+++ b/Sample-Programs/Hologram/ShellAndroid.cpp
@@ -103,8 +103,6 @@ std::vector<std::string> ShellAndroid::get_args(android_app &app) {
 
 ShellAndroid::ShellAndroid(android_app &app, Game &game) : Shell(game), app_(app) {
     instance_extensions_.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-
-    app_dummy();
     app_.userData = this;
     app_.onAppCmd = on_app_cmd;
     app_.onInputEvent = on_input_event;

--- a/Sample-Programs/Hologram/android/CMakeLists.txt
+++ b/Sample-Programs/Hologram/android/CMakeLists.txt
@@ -32,6 +32,11 @@ set(CMAKE_CXX_FLAGS
             -Wextra -Wno-unused-parameter \
             -DVK_NO_PROTOTYPES -DVK_USE_PLATFORM_ANDROID_KHR \
             -DGLM_FORCE_RADIANS")
+
+# Force export ANativeActivity_onCreate(),
+# Refer to: https://github.com/android-ndk/ndk/issues/381.
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
+
 add_library(Hologram SHARED
             ${hologramDir}/Shell.cpp
             ${hologramDir}/ShellAndroid.cpp


### PR DESCRIPTION
Hologram is not build with -Werror, app_dummy() issue is not causing error. This fix is "nice to have" category

@cnorthrop please kindly take a look.  thanks 