### PR TITLE
fix update_external_sources command for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ mkdir build
 cd build
 cmake -G "Visual Studio 12 Win64" ..
 ```
+Use the major version number reported by Visual Studio in Help->About.
 
 At this point, you can use Windows Explorer to launch Visual Studio by double-clicking on the "VULKAN.sln" file in the \build folder.  
 Once Visual Studio comes up, you can select "Debug" or "Release" from a drop-down list.  

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone git@github.com:LunarG/VulkanSamples.git
 cd VulkanSamples
 # This will fetch and build glslang and spriv-tools
 ./update_external_sources.sh         # linux
-./update_external_sources.bat --all  # windows
+update_external_sources.bat --all  # windows
 ```
 ## Linux Build
 


### PR DESCRIPTION
Fixes the command to invoke `update_external_sources.bat` for Windows, which doesn't work with the unix-style `./` prepended. Note: while this change allows the command to be invoked, it's failing to complete for another reason, #143.