### PR TITLE
demos: cube - iterating over compositeAlphaFlags - error in for loop condition

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -1250,7 +1250,7 @@ static void demo_prepare_buffers(struct demo *demo) {
         VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR,
         VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR,
     };
-    for (uint32_t i = 0; i < sizeof(compositeAlphaFlags); i++) {
+    for (uint32_t i = 0; i < ARRAY_SIZE(compositeAlphaFlags); i++) {
         if (surfCapabilities.supportedCompositeAlpha & compositeAlphaFlags[i]) {
             compositeAlpha = compositeAlphaFlags[i];
             break;

--- a/demos/cube.cpp
+++ b/demos/cube.cpp
@@ -1604,7 +1604,7 @@ Demo::Demo()
             vk::CompositeAlphaFlagBitsKHR::ePostMultiplied,
             vk::CompositeAlphaFlagBitsKHR::eInherit,
         };
-        for (uint32_t i = 0; i < std::size(compositeAlphaFlags); i++) {
+        for (uint32_t i = 0; i < ARRAY_SIZE(compositeAlphaFlags); i++) {
             if (surfCapabilities.supportedCompositeAlpha & compositeAlphaFlags[i]) {
                 compositeAlpha = compositeAlphaFlags[i];
                 break;

--- a/demos/cube.cpp
+++ b/demos/cube.cpp
@@ -1604,7 +1604,7 @@ Demo::Demo()
             vk::CompositeAlphaFlagBitsKHR::ePostMultiplied,
             vk::CompositeAlphaFlagBitsKHR::eInherit,
         };
-        for (uint32_t i = 0; i < sizeof(compositeAlphaFlags); i++) {
+        for (uint32_t i = 0; i < std::size(compositeAlphaFlags); i++) {
             if (surfCapabilities.supportedCompositeAlpha & compositeAlphaFlags[i]) {
                 compositeAlpha = compositeAlphaFlags[i];
                 break;


### PR DESCRIPTION
In the following code, there is a problem with a for loop condition that could lead to reading uninitialized memory hence to undefined behaviour.
sizeof(compositeAlphaFlags) returns total size of compositeAlphaFlags array in bytes. Not elements' count.
I propose to use ARRAY_SIZE macro (for C version) and std::size() overload for builtin arrays (for C++ version of the demo).

    VkCompositeAlphaFlagBitsKHR compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
    VkCompositeAlphaFlagBitsKHR compositeAlphaFlags[4] = {
          .......
    };
    for (uint32_t i = 0; i < sizeof(compositeAlphaFlags); i++) {
        if (surfCapabilities.supportedCompositeAlpha & compositeAlphaFlags[i]) {
            compositeAlpha = compositeAlphaFlags[i];
            break;
        }
    }
