### PR TITLE
samples: Query layer device extensions in init_enumerate_device

### DIFF
--- a/API-Samples/instance_layer_extension_properties/instance_layer_extension_properties.cpp
+++ b/API-Samples/instance_layer_extension_properties/instance_layer_extension_properties.cpp
@@ -85,8 +85,8 @@ int sample_main(int argc, char *argv[]) {
                     break;
                 }
 
-                layer_props.extensions.resize(instance_extension_count);
-                instance_extensions = layer_props.extensions.data();
+                layer_props.instance_extensions.resize(instance_extension_count);
+                instance_extensions = layer_props.instance_extensions.data();
                 res = vkEnumerateInstanceExtensionProperties(layer_name, &instance_extension_count, instance_extensions);
             } while (res == VK_INCOMPLETE);
         }
@@ -107,12 +107,12 @@ int sample_main(int argc, char *argv[]) {
              it++) {
             layer_properties *props = &(*it);
             std::cout << props->properties.layerName << std::endl;
-            if (props->extensions.size() > 0) {
-                for (uint32_t j = 0; j < props->extensions.size(); j++) {
+            if (props->instance_extensions.size() > 0) {
+                for (uint32_t j = 0; j < props->instance_extensions.size(); j++) {
                     if (j > 0) {
                         std::cout << ", ";
                     }
-                    std::cout << props->extensions[j].extensionName << " Version " << props->extensions[j].specVersion;
+                    std::cout << props->instance_extensions[j].extensionName << " Version " << props->instance_extensions[j].specVersion;
                 }
             } else {
                 std::cout << "Layer Extensions: None";

--- a/API-Samples/utils/util.hpp
+++ b/API-Samples/utils/util.hpp
@@ -128,7 +128,8 @@ typedef struct _swap_chain_buffers {
  */
 typedef struct {
     VkLayerProperties properties;
-    std::vector<VkExtensionProperties> extensions;
+    std::vector<VkExtensionProperties> instance_extensions;
+    std::vector<VkExtensionProperties> device_extensions;
 } layer_properties;
 
 /*

--- a/API-Samples/utils/util_init.cpp
+++ b/API-Samples/utils/util_init.cpp
@@ -54,8 +54,8 @@ VkResult init_global_extension_properties(layer_properties &layer_props) {
             return VK_SUCCESS;
         }
 
-        layer_props.extensions.resize(instance_extension_count);
-        instance_extensions = layer_props.extensions.data();
+        layer_props.instance_extensions.resize(instance_extension_count);
+        instance_extensions = layer_props.instance_extensions.data();
         res = vkEnumerateInstanceExtensionProperties(layer_name, &instance_extension_count, instance_extensions);
     } while (res == VK_INCOMPLETE);
 
@@ -136,8 +136,8 @@ VkResult init_device_extension_properties(struct sample_info &info, layer_proper
             return VK_SUCCESS;
         }
 
-        layer_props.extensions.resize(device_extension_count);
-        device_extensions = layer_props.extensions.data();
+        layer_props.device_extensions.resize(device_extension_count);
+        device_extensions = layer_props.device_extensions.data();
         res = vkEnumerateDeviceExtensionProperties(info.gpus[0], layer_name, &device_extension_count, device_extensions);
     } while (res == VK_INCOMPLETE);
 
@@ -258,6 +258,10 @@ VkResult init_enumerate_device(struct sample_info &info, uint32_t gpu_count) {
     /* This is as good a place as any to do this */
     vkGetPhysicalDeviceMemoryProperties(info.gpus[0], &info.memory_properties);
     vkGetPhysicalDeviceProperties(info.gpus[0], &info.gpu_props);
+    /* query device extensions for enabled layers */
+    for (auto& layer_props : info.instance_layer_properties) {
+      init_device_extension_properties(info, layer_props);
+    }
 
     return res;
 }


### PR DESCRIPTION
The sample framework currently queries the instance extensions exposed by each layer.
With this PR, device extensions are queried as well, and stored in a separate vector.
Renamed existing extension vector to "instance_extensions" for clarity.