### PR TITLE
scripts: python is no longer invoked via absolute path

### DIFF
--- a/update_external_sources.bat
+++ b/update_external_sources.bat
@@ -300,7 +300,7 @@ REM // ======== Functions ======== //
    cd %GLSLANG_DIR%
    git clone %GLSLANG_GITURL% .
    git checkout %GLSLANG_REVISION%
-   C:\Python27\python.exe .\update_glslang_sources.py
+   python.exe .\update_glslang_sources.py
    if not exist %GLSLANG_DIR%\SPIRV (
       echo glslang source download failed!
       set errorCode=1
@@ -313,7 +313,7 @@ goto:eof
    cd %GLSLANG_DIR%
    git fetch --all
    git checkout %GLSLANG_REVISION%
-   C:\Python27\python.exe .\update_glslang_sources.py
+   python.exe .\update_glslang_sources.py
 goto:eof
 
 :create_spirv-tools


### PR DESCRIPTION
Other invocations of Python in the same file already used the relative path, so I guess this was just an oversight.