### PR TITLE
build: Fix appveyor sln filename

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -104,5 +104,5 @@ configuration:
 
 build:
   parallel: true                  # enable MSBuild parallel builds
-  project: build/VULKAN.sln       # path to Visual Studio solution or project
+  project: build/VULKAN_SAMPLES.sln # path to Visual Studio solution or project
   verbosity: quiet                # quiet|minimal|normal|detailed


### PR DESCRIPTION
The appveyor build got broken during the last trunk merge, since the sln file did not get changed from VULKAN.sln (which is the name in LVL) to VULKAN_SAMPLES.sln. This PR fixes that oversight.