### PR TITLE
android: Fix API-Samples build with NDK-r16

### DIFF
--- a/API-Samples/utils/util.cpp
+++ b/API-Samples/utils/util.cpp
@@ -23,8 +23,10 @@ VULKAN_SAMPLE_DESCRIPTION
 samples utility functions
 */
 
-#include <stdio.h>
 #include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
 #include <cstdlib>
 #include <iomanip>
 #include <fstream>


### PR DESCRIPTION
Include <string.h> for strncmp and <errno.h> for EACCES