### PR TITLE
Samples: Remove leftover SDK includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,11 +322,6 @@ endif()
 add_definitions(-DVULKAN_SAMPLES_BASE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/API-Samples/utils)
-if(WIN32)
-    include_directories(${CMAKE_SOURCE_DIR}\\..\\Include)
-else()
-    include_directories("/usr/include/vulkan")
-endif()
 
 option(BUILD_API_SAMPLES "Build API Samples " ON)
 option(BUILD_SAMPLE_LAYERS "Build Sample Layers " ON)


### PR DESCRIPTION
These includes, leftover from a time before we had separate cmake files for the SDK, can cause build failures due to older headers from libvulkan-dev.  They are best removed.