### PR TITLE
Update API-Samples and Hologram to be compatible with MoltenVK.

### DIFF
--- a/API-Samples/utils/util.cpp
+++ b/API-Samples/utils/util.cpp
@@ -43,7 +43,7 @@ samples utility functions
 // Static variable that keeps ANativeWindow and asset manager instances.
 static android_app *Android_application = nullptr;
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-#	include <MoltenGLSLToSPIRVConverter/GLSLToSPIRVConverter.h>
+#	include <MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.h>
 #else
 #	include "SPIRV/GlslangToSpv.h"
 #endif
@@ -278,32 +278,32 @@ void finalize_glslang() {}
 
 bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spirv) {
 
- 	MLNShaderStage shaderStage;
+ 	MVKShaderStage shaderStage;
  	switch (shader_type) {
 		 		case VK_SHADER_STAGE_VERTEX_BIT:
-		 			shaderStage = kMLNShaderStageVertex;
+		 			shaderStage = kMVKShaderStageVertex;
 		 			break;
 		 		case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
-		 			shaderStage = kMLNShaderStageTessControl;
+		 			shaderStage = kMVKShaderStageTessControl;
 		 			break;
 				case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
-		 			shaderStage = kMLNShaderStageTessEval;
+		 			shaderStage = kMVKShaderStageTessEval;
 		 			break;
 		 		case VK_SHADER_STAGE_GEOMETRY_BIT:
-		 			shaderStage = kMLNShaderStageGeometry;
+		 			shaderStage = kMVKShaderStageGeometry;
 		 			break;
 		 		case VK_SHADER_STAGE_FRAGMENT_BIT:
-		 			shaderStage = kMLNShaderStageFragment;
+		 			shaderStage = kMVKShaderStageFragment;
 		 			break;
 		 		case VK_SHADER_STAGE_COMPUTE_BIT:
-		 			shaderStage = kMLNShaderStageCompute;
+		 			shaderStage = kMVKShaderStageCompute;
 		 			break;
 		 		default:
-		 			shaderStage = kMLNShaderStageAuto;
+		 			shaderStage = kMVKShaderStageAuto;
 		 			break;
 	 	}
 
- 	molten::GLSLToSPIRVConverter glslConverter;
+ 	mvk::GLSLToSPIRVConverter glslConverter;
  	glslConverter.setGLSL(pshader);
  	bool wasConverted = glslConverter.convert(shaderStage, false, false);
  	if (wasConverted) { spirv = glslConverter.getSPIRV(); }

--- a/API-Samples/utils/util.cpp
+++ b/API-Samples/utils/util.cpp
@@ -43,9 +43,9 @@ samples utility functions
 // Static variable that keeps ANativeWindow and asset manager instances.
 static android_app *Android_application = nullptr;
 #elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-#	include <MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.h>
+#include <MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.h>
 #else
-#	include "SPIRV/GlslangToSpv.h"
+#include "SPIRV/GlslangToSpv.h"
 #endif
 
 // For timestamp code (get_milliseconds)
@@ -277,40 +277,41 @@ void init_glslang() {}
 void finalize_glslang() {}
 
 bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spirv) {
+    MVKShaderStage shaderStage;
+    switch (shader_type) {
+        case VK_SHADER_STAGE_VERTEX_BIT:
+            shaderStage = kMVKShaderStageVertex;
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
+            shaderStage = kMVKShaderStageTessControl;
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
+            shaderStage = kMVKShaderStageTessEval;
+            break;
+        case VK_SHADER_STAGE_GEOMETRY_BIT:
+            shaderStage = kMVKShaderStageGeometry;
+            break;
+        case VK_SHADER_STAGE_FRAGMENT_BIT:
+            shaderStage = kMVKShaderStageFragment;
+            break;
+        case VK_SHADER_STAGE_COMPUTE_BIT:
+            shaderStage = kMVKShaderStageCompute;
+            break;
+        default:
+            shaderStage = kMVKShaderStageAuto;
+            break;
+    }
 
- 	MVKShaderStage shaderStage;
- 	switch (shader_type) {
-		 		case VK_SHADER_STAGE_VERTEX_BIT:
-		 			shaderStage = kMVKShaderStageVertex;
-		 			break;
-		 		case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
-		 			shaderStage = kMVKShaderStageTessControl;
-		 			break;
-				case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
-		 			shaderStage = kMVKShaderStageTessEval;
-		 			break;
-		 		case VK_SHADER_STAGE_GEOMETRY_BIT:
-		 			shaderStage = kMVKShaderStageGeometry;
-		 			break;
-		 		case VK_SHADER_STAGE_FRAGMENT_BIT:
-		 			shaderStage = kMVKShaderStageFragment;
-		 			break;
-		 		case VK_SHADER_STAGE_COMPUTE_BIT:
-		 			shaderStage = kMVKShaderStageCompute;
-		 			break;
-		 		default:
-		 			shaderStage = kMVKShaderStageAuto;
-		 			break;
-	 	}
+    mvk::GLSLToSPIRVConverter glslConverter;
+    glslConverter.setGLSL(pshader);
+    bool wasConverted = glslConverter.convert(shaderStage, false, false);
+    if (wasConverted) {
+        spirv = glslConverter.getSPIRV();
+    }
+    return wasConverted;
+}
 
- 	mvk::GLSLToSPIRVConverter glslConverter;
- 	glslConverter.setGLSL(pshader);
- 	bool wasConverted = glslConverter.convert(shaderStage, false, false);
- 	if (wasConverted) { spirv = glslConverter.getSPIRV(); }
- 	return wasConverted;
- }
-
-#else   // not IOS OR macOS
+#else  // not IOS OR macOS
 
 #ifndef __ANDROID__
 void init_resources(TBuiltInResource &Resources) {

--- a/Sample-Programs/Hologram/Hologram.cpp
+++ b/Sample-Programs/Hologram/Hologram.cpp
@@ -213,7 +213,7 @@ void Hologram::create_render_pass() {
 #ifdef MVK_USE_MOLTENVK_SHADER_CONVERTER
 
 #include <MoltenVK/vk_mvk_moltenvk.h>
-#include <MoltenGLSLToSPIRVConverter/GLSLConversion.h>
+#include <MoltenVKGLSLToSPIRVConverter/GLSLConversion.h>
 void Hologram::create_shader_modules() {
 
 #ifdef DEBUG
@@ -234,7 +234,7 @@ void Hologram::create_shader_modules() {
 
     // Vertex shader
     filename = use_push_constants_ ? "Hologram.push_constant.vert" : "Hologram.vert";
-    wasConverted = mlnConvertGLSLFileToSPIRV(filename, kMLNShaderStageVertex,
+    wasConverted = mvkConvertGLSLFileToSPIRV(filename, kMVKShaderStageVertex,
                                              (uint32_t**)&sh_info.pCode, &sh_info.codeSize,
                                              &spvLog, true, true);
     if ( !wasConverted ) { printf("Could not convert GLSL to SPIRV:\n%s", spvLog); }
@@ -244,7 +244,7 @@ void Hologram::create_shader_modules() {
 
     // Fragment shader
     filename = "Hologram.frag";
-    wasConverted = mlnConvertGLSLFileToSPIRV(filename, kMLNShaderStageFragment,
+    wasConverted = mvkConvertGLSLFileToSPIRV(filename, kMVKShaderStageFragment,
                                              (uint32_t**)&sh_info.pCode, &sh_info.codeSize,
                                              &spvLog, true, true);
     if ( !wasConverted ) { printf("Could not convert GLSL to SPIRV:\n%s", spvLog); }

--- a/Sample-Programs/Hologram/Hologram.cpp
+++ b/Sample-Programs/Hologram/Hologram.cpp
@@ -215,42 +215,43 @@ void Hologram::create_render_pass() {
 #include <MoltenVK/vk_mvk_moltenvk.h>
 #include <MoltenVKGLSLToSPIRVConverter/GLSLConversion.h>
 void Hologram::create_shader_modules() {
-
 #ifdef DEBUG
     // If debugging, enable MoltenVK debug mode to enable debugging capabilities,
     // including logging shader conversions from SPIR-V to Metal Shading Language.
     MVKDeviceConfiguration mvkConfig;
-    vkGetMoltenVKDeviceConfigurationMVK(dev_, &mvkConfig );
+    vkGetMoltenVKDeviceConfigurationMVK(dev_, &mvkConfig);
     mvkConfig.debugMode = true;
-    vkSetMoltenVKDeviceConfigurationMVK(dev_, &mvkConfig );
+    vkSetMoltenVKDeviceConfigurationMVK(dev_, &mvkConfig);
 #endif
 
-    char* spvLog;
+    char *spvLog;
     bool wasConverted;
 
-    const char* filename;
+    const char *filename;
     VkShaderModuleCreateInfo sh_info = {};
     sh_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
 
     // Vertex shader
     filename = use_push_constants_ ? "Hologram.push_constant.vert" : "Hologram.vert";
-    wasConverted = mvkConvertGLSLFileToSPIRV(filename, kMVKShaderStageVertex,
-                                             (uint32_t**)&sh_info.pCode, &sh_info.codeSize,
+    wasConverted = mvkConvertGLSLFileToSPIRV(filename, kMVKShaderStageVertex, (uint32_t **)&sh_info.pCode, &sh_info.codeSize,
                                              &spvLog, true, true);
-    if ( !wasConverted ) { printf("Could not convert GLSL to SPIRV:\n%s", spvLog); }
+    if (!wasConverted) {
+        printf("Could not convert GLSL to SPIRV:\n%s", spvLog);
+    }
     vk::assert_success(vk::CreateShaderModule(dev_, &sh_info, nullptr, &vs_));
-    free((void*)sh_info.pCode);
-    free((void*)spvLog);
+    free((void *)sh_info.pCode);
+    free((void *)spvLog);
 
     // Fragment shader
     filename = "Hologram.frag";
-    wasConverted = mvkConvertGLSLFileToSPIRV(filename, kMVKShaderStageFragment,
-                                             (uint32_t**)&sh_info.pCode, &sh_info.codeSize,
+    wasConverted = mvkConvertGLSLFileToSPIRV(filename, kMVKShaderStageFragment, (uint32_t **)&sh_info.pCode, &sh_info.codeSize,
                                              &spvLog, true, true);
-    if ( !wasConverted ) { printf("Could not convert GLSL to SPIRV:\n%s", spvLog); }
+    if (!wasConverted) {
+        printf("Could not convert GLSL to SPIRV:\n%s", spvLog);
+    }
     vk::assert_success(vk::CreateShaderModule(dev_, &sh_info, nullptr, &fs_));
-    free((void*)sh_info.pCode);
-    free((void*)spvLog);
+    free((void *)sh_info.pCode);
+    free((void *)spvLog);
 }
 
 #else
@@ -275,7 +276,7 @@ void Hologram::create_shader_modules() {
     vk::assert_success(vk::CreateShaderModule(dev_, &sh_info, nullptr, &fs_));
 }
 
-#endif      // HG_USE_MOLTENVK_SHADER_CONVERTER
+#endif  // HG_USE_MOLTENVK_SHADER_CONVERTER
 
 void Hologram::create_descriptor_set_layout() {
     if (use_push_constants_) return;


### PR DESCRIPTION
This update makes the API-Samples and Hologram demos compatible with the open-source version of MoltenVK, which has a slightly different extended API than the previous licensed version.