### PR TITLE
samples: Enable Android build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ matrix:
   fast_finish: true
   include:
     # Android build.
-    - os: linux
-      compiler: gcc
-      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=armeabi-v7a
-    # Android 64-bit build.
-    - os: linux
-      compiler: gcc
-      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=arm64-v8a
+    - language: android
+      android:
+        components:
+          - build-tools-26.0.2
+          - android-26
+          - extra
+      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_ABI=armeabi-v7a
     # Linux GCC debug build.
     - os: linux
       compiler: gcc
@@ -54,6 +54,10 @@ before_install:
       export ANDROID_NDK_HOME=`pwd`/android-ndk-r15c
       export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
       export PATH="$ANDROID_NDK_HOME:$PATH"
+      pushd android-ndk-r15c
+      yes | sdkmanager --update
+      yes | sdkmanager --licenses
+      popd
     fi
   - |
     if [[ "$CHECK_FORMAT" == "ON" && "$TRAVIS_PULL_REQUEST" != "false" ]]; then
@@ -70,11 +74,13 @@ script:
   - |
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then
-      pushd build-android
-      ./update_external_sources_android.sh --abi $ANDROID_ABI --no-build
-      ./android-generate.sh
-      USE_CCACHE=1 NDK_CCACHE=ccache ndk-build APP_ABI=$ANDROID_ABI -j $core_count
+      pushd android-ndk-r15c/sources/third_party/shaderc
+      ../../../ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=Android.mk APP_STL:=c++_static APP_ABI=$ANDROID_ABI NDK_TOOLCHAIN_VERSION:=clang libshaderc_combined -j16
       popd
+      cd API-Samples
+      cmake -DANDROID=ON -DABI_NAME=$ANDROID_ABI
+      cd android
+      ./gradlew build
     fi
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Build VulkanSamples

--- a/API-Samples/16-vulkan_1_1/16-vulkan_1_1.cpp
+++ b/API-Samples/16-vulkan_1_1/16-vulkan_1_1.cpp
@@ -32,6 +32,9 @@ int sample_main(int argc, char *argv[]) {
     struct sample_info info = {};
     init_global_layer_properties(info);
 
+// Android build not at 1.1 yet
+#ifndef ANDROID
+
     /* VULKAN_KEY_START */
 
     // Keep track of the major/minor version we can actually use
@@ -135,6 +138,7 @@ int sample_main(int argc, char *argv[]) {
         vkDestroyInstance(instance, NULL);
     }
 
+#endif
     /* VULKAN_KEY_END */
 
     return 0;

--- a/API-Samples/CMakeLists.txt
+++ b/API-Samples/CMakeLists.txt
@@ -270,11 +270,11 @@ set (S_TARGETS
     spirv_assembly spirv_specialization memory_barriers validation_cache vulkan_1_1_flexible)
 sampleWithSingleFile()
 
+if (NOT ANDROID)
 foreach (sample ${S_TARGETS})
     install(TARGETS ${sample} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endforeach(sample)
 
-if (NOT ANDROID)
     add_subdirectory(utils)
 endif()
 

--- a/API-Samples/android/project_template/build.gradle
+++ b/API-Samples/android/project_template/build.gradle
@@ -42,7 +42,7 @@ android {
         versionCode  1
         versionName '0.0.1'
         ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+            abiFilters '@ABI_NAME@'
         }
         externalNativeBuild {
             cmake {

--- a/API-Samples/validation_cache/validation_cache.cpp
+++ b/API-Samples/validation_cache/validation_cache.cpp
@@ -78,12 +78,6 @@ struct ShaderVariant {
 };
 
 int sample_main(int argc, char *argv[]) {
-#if !defined(VK_EXT_validation_cache)
-    fprintf(stderr, "%s not defined at build time.\n", VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
-    fprintf(stderr, "To build this sample, update your Vulkan SDK to 1.0.61 or later.\n");
-    return 0;
-#endif
-
     VkResult U_ASSERT_ONLY res;
     struct sample_info info = {};
     char sample_title[] = "Validation Cache";
@@ -91,6 +85,14 @@ int sample_main(int argc, char *argv[]) {
 
     process_command_line_args(info, argc, argv);
     init_global_layer_properties(info);
+// Android headers don't have validation cache yet
+#ifndef ANDROID
+#if !defined(VK_EXT_validation_cache)
+    fprintf(stderr, "%s not defined at build time.\n", VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
+    fprintf(stderr, "To build this sample, update your Vulkan SDK to 1.0.61 or later.\n");
+    return 0;
+#endif
+
     init_instance_extension_names(info);
     init_device_extension_names(info);
     // The VK_EXT_validation_cache extension is implemented by the validation layers, so
@@ -435,5 +437,6 @@ int sample_main(int argc, char *argv[]) {
     destroy_device(info);
     destroy_window(info);
     destroy_instance(info);
+#endif
     return 0;
 }

--- a/API-Samples/vulkan_1_1_flexible/vulkan_1_1_flexible.cpp
+++ b/API-Samples/vulkan_1_1_flexible/vulkan_1_1_flexible.cpp
@@ -32,6 +32,8 @@ int sample_main(int argc, char *argv[]) {
     struct sample_info info = {};
     init_global_layer_properties(info);
 
+// Android build not at 1.1 yet
+#ifndef ANDROID
     /* VULKAN_KEY_START */
 
     // Keep track of the major/minor version we can actually use
@@ -138,7 +140,7 @@ int sample_main(int argc, char *argv[]) {
     if (VK_NULL_HANDLE == instance) {
         vkDestroyInstance(instance, NULL);
     }
-
+#endif
     /* VULKAN_KEY_END */
 
     return 0;


### PR DESCRIPTION
This attempts to enable the android build of Samples in Travis.  It currently takes too long and times out, so I'm looking for suggestions for shortening the build time.  Would building fewer ABIs be possible?