### PR TITLE
Hologram sample upgraded to use MoltenVK VkInstance config instead of VkDevice config.

### DIFF
--- a/Sample-Programs/Hologram/Hologram.cpp
+++ b/Sample-Programs/Hologram/Hologram.cpp
@@ -218,10 +218,13 @@ void Hologram::create_shader_modules() {
 #ifdef DEBUG
     // If debugging, enable MoltenVK debug mode to enable debugging capabilities,
     // including logging shader conversions from SPIR-V to Metal Shading Language.
-    MVKDeviceConfiguration mvkConfig;
-    vkGetMoltenVKDeviceConfigurationMVK(dev_, &mvkConfig);
+	// Be aware, changing the value of some of the members of MVKConfiguration must be
+	// performed before the device is created, in order for the change to take affect.
+    MVKConfiguration mvkConfig;
+	VkInstance vkInst = shell_->context().instance;
+    vkGetMoltenVKConfigurationMVK(vkInst, &mvkConfig);
     mvkConfig.debugMode = true;
-    vkSetMoltenVKDeviceConfigurationMVK(dev_, &mvkConfig);
+    vkSetMoltenVKConfigurationMVK(vkInst, &mvkConfig);
 #endif
 
     char *spvLog;

--- a/Sample-Programs/Hologram/Hologram.cpp
+++ b/Sample-Programs/Hologram/Hologram.cpp
@@ -218,10 +218,10 @@ void Hologram::create_shader_modules() {
 #ifdef DEBUG
     // If debugging, enable MoltenVK debug mode to enable debugging capabilities,
     // including logging shader conversions from SPIR-V to Metal Shading Language.
-	// Be aware, changing the value of some of the members of MVKConfiguration must be
-	// performed before the device is created, in order for the change to take affect.
+    // Be aware, changing the value of some of the members of MVKConfiguration must be
+    // performed before the device is created, in order for the change to take affect.
     MVKConfiguration mvkConfig;
-	VkInstance vkInst = shell_->context().instance;
+    VkInstance vkInst = shell_->context().instance;
     vkGetMoltenVKConfigurationMVK(vkInst, &mvkConfig);
     mvkConfig.debugMode = true;
     vkSetMoltenVKConfigurationMVK(vkInst, &mvkConfig);


### PR DESCRIPTION
Hologram sample source demonstrates MoltenVK runtime config. MoltenVK runtime config has moved from VkDevice to VkInstance. This PR updates the use of MoltenVK config in the Hologram sample.
