### PR TITLE
Remove all build errors on Android Studio 3.2.0

### DIFF
--- a/API-Samples/android/build.gradle
+++ b/API-Samples/android/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016, 2018 Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/API-Samples/android/build.gradle
+++ b/API-Samples/android/build.gradle
@@ -16,10 +16,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -27,6 +28,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/API-Samples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/API-Samples/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/API-Samples/android/project_template/build.gradle
+++ b/API-Samples/android/project_template/build.gradle
@@ -32,13 +32,13 @@ if(!ndkDir || ndkDir.empty) {
 def stlType = 'c++_static'
 
 android {
-    compileSdkVersion  24
-    buildToolsVersion '25.0.0'
+    compileSdkVersion  26
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         applicationId '@PACKAGE_NAME@'
         minSdkVersion    22
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode  1
         versionName '0.0.1'
         ndk {
@@ -69,5 +69,5 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/API-Samples/android/project_template/build.gradle
+++ b/API-Samples/android/project_template/build.gradle
@@ -33,11 +33,10 @@ def stlType = 'c++_static'
 
 android {
     compileSdkVersion  26
-    buildToolsVersion '28.0.2'
 
     defaultConfig {
         applicationId '@PACKAGE_NAME@'
-        minSdkVersion    22
+        minSdkVersion    24 // Official vulkan support starts in version 24
         targetSdkVersion 26
         versionCode  1
         versionName '0.0.1'

--- a/API-Samples/android/project_template/build.gradle
+++ b/API-Samples/android/project_template/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016, 2018 Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/API-Samples/android/project_template/src/main/AndroidManifest.xml
+++ b/API-Samples/android/project_template/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@ limitations under the License.
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="@PACKAGE_NAME@">
 
-    <uses-permission android:name="android.permission.SET_DEBUG_APP"/>
     @EXTRA_PERMISSIONS@
     <!-- This .apk has no Java code itself, so set hasCode to false. -->
     <application android:label="@string/app_name" 

--- a/API-Samples/android/project_template/src/main/AndroidManifest.xml
+++ b/API-Samples/android/project_template/src/main/AndroidManifest.xml
@@ -16,12 +16,7 @@ limitations under the License.
 -->
 <!-- BEGIN_INCLUDE(manifest) -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-        package="@PACKAGE_NAME@"
-        android:versionCode="1"
-        android:versionName="1.0">
-
-    <!-- This is the platform API where NativeActivity was introduced. -->
-    <uses-sdk android:minSdkVersion="22" />
+        package="@PACKAGE_NAME@">
 
     <uses-permission android:name="android.permission.SET_DEBUG_APP"/>
     @EXTRA_PERMISSIONS@

--- a/API-Samples/android/project_template/src/main/AndroidManifest.xml
+++ b/API-Samples/android/project_template/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Copyright 2016 Google Inc. All rights reserved.
+Copyright 2016, 2018 Google Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update Gradle version and fix build files in order to get rid of all
warnings and errors when building through the latest Android Studio
3.2.0. Also remove some obsolete entries of the AndroidManifest,
which are now set by Gradle.
