### PR TITLE
Fix init_command_buffer order of calls

### DIFF
--- a/API-Samples/04-init_command_buffer/04-init_command_buffer.cpp
+++ b/API-Samples/04-init_command_buffer/04-init_command_buffer.cpp
@@ -36,8 +36,8 @@ int sample_main(int argc, char *argv[]) {
     init_global_layer_properties(info);
     init_instance(info, sample_title);
     init_enumerate_device(info);
-    init_device(info);
     init_queue_family_index(info);
+    init_device(info);
 
     /* VULKAN_KEY_START */
 


### PR DESCRIPTION
Must call init_queue_family_index before calling init_device

Change-Id: Ic2855e317487943604bd70bf1bb6e0c154a23790