### PR TITLE
Compare to `None` using identity `is` operator

### DIFF
--- a/scripts/cgenerator.py
+++ b/scripts/cgenerator.py
@@ -185,7 +185,7 @@ class COutputGenerator(OutputGenerator):
             # If type declarations are needed by other features based on
             # this one, it may be necessary to suppress the ExtraProtect,
             # or move it below the 'for section...' loop.
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#ifdef', self.featureExtraProtect, file=self.outFile)
             write('#define', self.featureName, '1', file=self.outFile)
             for section in self.TYPE_SECTIONS:
@@ -205,7 +205,7 @@ class COutputGenerator(OutputGenerator):
                     write('#endif', file=self.outFile)
                 else:
                     self.newline()
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#endif /*', self.featureExtraProtect, '*/', file=self.outFile)
             if (self.genOpts.protectFeature):
                 write('#endif /*', self.featureName, '*/', file=self.outFile)
@@ -317,7 +317,7 @@ class COutputGenerator(OutputGenerator):
                 body += "    " + name + " = " + strVal + ",\n"
 
             if (isEnum and elem.get('extends') is None):
-                if (minName == None):
+                if (minName is None):
                     minName = maxName = name
                     minValue = maxValue = numVal
                 elif (numVal < minValue):

--- a/scripts/determine_vs_version.py
+++ b/scripts/determine_vs_version.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
 
     # If not found, return an invalid number but in the appropriate format so it will
     # fail if the program above tries to use it.
-    if foundExeName == None:
+    if foundExeName is None:
         print('00 0000')
         print('Executable ' + exeName + ' not found in PATH!')
     else:
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         for spaceString in spaceList:
 
             # If we've already found it, bail.
-            if version != None:
+            if version is not None:
                 break
         
             # Now split around line feeds
@@ -94,7 +94,7 @@ if __name__ == '__main__':
             for curLine in lineList:
 
                 # If we've already found it, bail.
-                if version != None:
+                if version is not None:
                     break
             
                 # We only want to continue if there's a period in the list
@@ -109,7 +109,7 @@ if __name__ == '__main__':
                     break
         
         # Failsafe to return a number in the proper format, but one that will fail.
-        if version == None:
+        if version is None:
             version = 00
 
         # Determine the year associated with that version

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -161,7 +161,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
     # Determine if this API should be ignored or added to the instance or device dispatch table
     def AddCommandToDispatchList(self, name, handle_type, protect):
         handle = self.registry.tree.find("types/type/[name='" + handle_type + "'][@category='handle']")
-        if handle == None:
+        if handle is None:
             return
         if handle_type != 'VkInstance' and handle_type != 'VkPhysicalDevice' and name != 'vkGetInstanceProcAddr':
             self.device_dispatch_list.append((name, self.featureExtraProtect))

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -141,7 +141,7 @@ class GeneratorOptions:
     # Substitute a regular expression which matches no version
     # or extension names for None or the empty string.
     def emptyRegex(self,pat):
-        if (pat == None or pat == ''):
+        if (pat is None or pat == ''):
             return '_nomatch_^'
         else:
             return pat
@@ -231,14 +231,14 @@ class OutputGenerator:
         if (level == 'error'):
             strfile = io.StringIO()
             write('ERROR:', *args, file=strfile)
-            if (self.errFile != None):
+            if (self.errFile is not None):
                 write(strfile.getvalue(), file=self.errFile)
             raise UserWarning(strfile.getvalue())
         elif (level == 'warn'):
-            if (self.warnFile != None):
+            if (self.warnFile is not None):
                 write('WARNING:', *args, file=self.warnFile)
         elif (level == 'diag'):
-            if (self.diagFile != None):
+            if (self.diagFile is not None):
                 write('DIAG:', *args, file=self.diagFile)
         else:
             raise UserWarning(
@@ -271,7 +271,7 @@ class OutputGenerator:
             # If there's a non-integer, numeric 'type' attribute (e.g. 'u' or
             # 'ull'), append it to the string value.
             # t = enuminfo.elem.get('type')
-            # if (t != None and t != '' and t != 'i' and t != 's'):
+            # if (t is not None and t != '' and t != 'i' and t != 's'):
             #     value += enuminfo.type
             self.logMsg('diag', 'Enum', name, '-> value [', numVal, ',', value, ']')
             return [numVal, value]
@@ -318,7 +318,7 @@ class OutputGenerator:
         #
         # Open specified output file. Not done in constructor since a
         # Generator can be used without writing to a file.
-        if (self.genOpts.filename != None):
+        if (self.genOpts.filename is not None):
             filename = self.genOpts.directory + '/' + self.genOpts.filename
             self.outFile = io.open(filename, 'w', encoding='utf-8')
         else:
@@ -344,7 +344,7 @@ class OutputGenerator:
     # Utility method to validate we're generating something only inside a
     # <feature> tag
     def validateFeature(self, featureType, featureName):
-        if (self.featureName == None):
+        if (self.featureName is None):
             raise UserWarning('Attempt to generate', featureType, name,
                     'when not in feature')
     #

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -412,10 +412,10 @@ class HelperFileOutputGenerator(OutputGenerator):
         outstring += 'size_t get_struct_size(const void* struct_ptr);\n'
         for item in self.structMembers:
             lower_case_name = item.name.lower()
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 outstring += '#ifdef %s\n' % item.ifdef_protect
             outstring += 'size_t vk_size_%s(const %s* struct_ptr);\n' % (item.name.lower(), item.name)
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 outstring += '#endif // %s\n' % item.ifdef_protect
         outstring += '#ifdef __cplusplus\n'
         outstring += '}\n'
@@ -490,7 +490,7 @@ class HelperFileOutputGenerator(OutputGenerator):
         for item in self.structMembers:
             struct_size_funcs += '\n'
             lower_case_name = item.name.lower()
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 struct_size_funcs += '#ifdef %s\n' % item.ifdef_protect
                 struct_size += '#ifdef %s\n' % item.ifdef_protect
                 chain_size += '#ifdef %s\n' % item.ifdef_protect
@@ -538,7 +538,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             struct_size_funcs += '    }\n'
             struct_size_funcs += '    return struct_size;\n'
             struct_size_funcs += '}\n'
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 struct_size_funcs += '#endif // %s\n' % item.ifdef_protect
                 struct_size += '#endif // %s\n' % item.ifdef_protect
                 chain_size += '#endif // %s\n' % item.ifdef_protect
@@ -573,7 +573,7 @@ class HelperFileOutputGenerator(OutputGenerator):
         for item in self.structMembers:
             if self.NeedSafeStruct(item) == True:
                 safe_struct_header += '\n'
-                if item.ifdef_protect != None:
+                if item.ifdef_protect is not None:
                     safe_struct_header += '#ifdef %s\n' % item.ifdef_protect
                 safe_struct_header += 'struct safe_%s {\n' % (item.name)
                 for member in item.members:
@@ -599,7 +599,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                 safe_struct_header += '    %s *ptr() { return reinterpret_cast<%s *>(this); }\n' % (item.name, item.name)
                 safe_struct_header += '    %s const *ptr() const { return reinterpret_cast<%s const *>(this); }\n' % (item.name, item.name)
                 safe_struct_header += '};\n'
-                if item.ifdef_protect != None:
+                if item.ifdef_protect is not None:
                     safe_struct_header += '#endif // %s\n' % item.ifdef_protect
         return safe_struct_header
     #
@@ -778,7 +778,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                 continue
             if item.name in wsi_structs:
                 continue
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 safe_struct_body.append("#ifdef %s\n" % item.ifdef_protect)
             ss_name = "safe_%s" % item.name
             init_list = ''          # list of members in struct constructor initializer
@@ -1086,7 +1086,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             init_copy = copy_construct_init.replace('src.', 'src->')
             init_construct = copy_construct_txt.replace('src.', 'src->')
             safe_struct_body.append("\nvoid %s::initialize(const %s* src)\n{\n%s%s}" % (ss_name, ss_name, init_copy, init_construct))
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 safe_struct_body.append("#endif // %s\n" % item.ifdef_protect)
         return "\n".join(safe_struct_body)
     #
@@ -1178,7 +1178,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             if not info:
                 continue
 
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 code.append('#ifdef %s' % item.ifdef_protect)
 
             code.append('// Map type {} to id {}'.format(typename, info.value))
@@ -1186,7 +1186,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                 id_decl=id_decl, id_member=id_member))
             code.append(idmap_format.format(template=idmap, typename=typename, id_value=info.value, typedef=type_member))
 
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 code.append('#endif // %s' % item.ifdef_protect)
 
         # Generate utilities for all types

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -251,7 +251,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             if os.path.isfile(vuid_filename):
                 self.vuid_file = open(vuid_filename, "r", encoding="utf8")
                 break
-        if self.vuid_file == None:
+        if self.vuid_file is None:
             print("Error: Could not find vk_validation_error_messages.h")
             sys.exit(1)
         os.chdir(previous_dir)
@@ -392,7 +392,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         # Actually write the interface to the output file.
         if (self.emit):
             self.newline()
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#ifdef', self.featureExtraProtect, file=self.outFile)
             # Write the object_tracker code to the file
             if (self.sections['command']):
@@ -400,7 +400,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
                     write(self.genOpts.protectProto,
                           self.genOpts.protectProtoStr, file=self.outFile)
                 write('\n'.join(self.sections['command']), end=u'', file=self.outFile)
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('\n#endif //', self.featureExtraProtect, file=self.outFile)
             else:
                 self.newline()
@@ -423,10 +423,10 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
 
         if self.featureName != 'VK_VERSION_1_0':
             white_list_entry = []
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 white_list_entry += [ '#ifdef %s' % self.featureExtraProtect ]
             white_list_entry += [ '"%s"' % self.featureName ]
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 white_list_entry += [ '#endif' ]
             featureType = interface.get('type')
             if featureType == 'instance':
@@ -906,7 +906,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             if not api_decls and not api_pre and not api_post:
                 continue
             feature_extra_protect = cmd_protect_dict[api_call.name]
-            if (feature_extra_protect != None):
+            if (feature_extra_protect is not None):
                 self.appendSection('command', '')
                 self.appendSection('command', '#ifdef '+ feature_extra_protect)
                 self.intercepts += [ '#ifdef %s' % feature_extra_protect ]
@@ -919,9 +919,9 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             self.appendSection('command', '    bool skip = false;')
             # Handle return values, if any
             resulttype = cmdinfo.elem.find('proto/type')
-            if (resulttype != None and resulttype.text == 'void'):
+            if (resulttype is not None and resulttype.text == 'void'):
               resulttype = None
-            if (resulttype != None):
+            if (resulttype is not None):
                 assignresult = resulttype.text + ' result = '
             else:
                 assignresult = ''
@@ -954,9 +954,9 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             # And add the post-API-call codegen
             self.appendSection('command', "\n".join(str(api_post).rstrip().split("\n")))
             # Handle the return result variable, if any
-            if (resulttype != None):
+            if (resulttype is not None):
                 self.appendSection('command', '    return result;')
             self.appendSection('command', '}')
-            if (feature_extra_protect != None):
+            if (feature_extra_protect is not None):
                 self.appendSection('command', '#endif // '+ feature_extra_protect)
                 self.intercepts += [ '#endif' ]

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -206,7 +206,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             if os.path.isfile(vuid_filename):
                 self.vuid_file = open(vuid_filename, "r", encoding="utf8")
                 break
-        if self.vuid_file == None:
+        if self.vuid_file is None:
             print("Error: Could not find vk_validation_error_messages.h")
             sys.exit(1)
         os.chdir(previous_dir)
@@ -392,7 +392,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             # If type declarations are needed by other features based on this one, it may be necessary to suppress the ExtraProtect,
             # or move it below the 'for section...' loop.
             ifdef = ''
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 ifdef = '#ifdef %s\n' % self.featureExtraProtect
                 self.validation.append(ifdef)
             # Generate the struct member checking code from the captured data
@@ -414,7 +414,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
                     decl += ';'
                     write(decl, file=self.outFile)
             endif = '\n'
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 endif = '#endif // %s\n' % self.featureExtraProtect
             self.validation.append(endif)
         # Finish processing in superclass
@@ -550,7 +550,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
         typedef = decls[1]
         typedef = typedef.split(')',1)[1]
         if name not in self.blacklist:
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 self.declarations += [ '#ifdef %s' % self.featureExtraProtect ]
                 self.intercepts += [ '#ifdef %s' % self.featureExtraProtect ]
                 if (name not in self.validate_only):
@@ -562,7 +562,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             self.intercepts += [ '    {"%s", (void*)%s},' % (name,name) ]
             # Strip off 'vk' from API name
             self.declarations += [ '%s' % decls[0].replace("VKAPI_CALL vk", "VKAPI_CALL ") ]
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 self.intercepts += [ '#endif' ]
                 self.declarations += [ '#endif' ]
                 if (name not in self.validate_only):
@@ -601,7 +601,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             # Save return value information, if any
             result_type = ''
             resultinfo = cmdinfo.elem.find('proto/type')
-            if (resultinfo != None and resultinfo.text != 'void'):
+            if (resultinfo is not None and resultinfo.text != 'void'):
                 result_type = resultinfo.text
             self.commands.append(self.CommandData(name=name, params=paramsInfo, cdecl=self.makeCDecls(cmdinfo.elem)[0], extension_type=self.extension_type, result=result_type))
     #

--- a/scripts/reg.py
+++ b/scripts/reg.py
@@ -51,14 +51,14 @@ def matchAPIProfile(api, profile, elem):
     match = True
     # Match 'api', if present
     if ('api' in elem.attrib):
-        if (api == None):
+        if (api is None):
             raise UserWarning("No API requested, but 'api' attribute is present with value '" +
                               elem.get('api') + "'")
         elif (api != elem.get('api')):
             # Requested API doesn't match attribute
             return False
     if ('profile' in elem.attrib):
-        if (profile == None):
+        if (profile is None):
             raise UserWarning("No profile requested, but 'profile' attribute is present with value '" +
                 elem.get('profile') + "'")
         elif (profile != elem.get('profile')):
@@ -112,7 +112,7 @@ class EnumInfo(BaseInfo):
     def __init__(self, elem):
         BaseInfo.__init__(self, elem)
         self.type = elem.get('type')
-        if (self.type == None):
+        if (self.type is None):
             self.type = ''
 
 # CmdInfo - registry information about a command
@@ -271,7 +271,7 @@ class Registry:
         for type in self.reg.findall('types/type'):
             # If the <type> doesn't already have a 'name' attribute, set
             # it from contents of its <name> tag.
-            if (type.get('name') == None):
+            if (type.get('name') is None):
                 type.attrib['name'] = type.find('name').text
             self.addElementInfo(type, TypeInfo(type), 'type', self.typedict)
         #
@@ -295,7 +295,7 @@ class Registry:
         # a better scheme for tagging core and extension enums is created.
         self.enumdict = {}
         for enums in self.reg.findall('enums'):
-            required = (enums.get('type') != None)
+            required = (enums.get('type') is not None)
             for enum in enums.findall('enum'):
                 enumInfo = EnumInfo(enum)
                 enumInfo.required = required
@@ -311,7 +311,7 @@ class Registry:
         for cmd in self.reg.findall('commands/command'):
             # If the <command> doesn't already have a 'name' attribute, set
             # it from contents of its <proto><name> tag.
-            if (cmd.get('name') == None):
+            if (cmd.get('name') is None):
                 cmd.attrib['name'] = cmd.find('proto/name').text
             ci = CmdInfo(cmd)
             self.addElementInfo(cmd, ci, 'command', self.cmddict)
@@ -363,7 +363,7 @@ class Registry:
               for enum in elem.findall('enum'):
                 addEnumInfo = False
                 groupName = enum.get('extends')
-                if (groupName != None):
+                if (groupName is not None):
                     # self.gen.logMsg('diag', '*** Found extension enum',
                     #     enum.get('name'))
                     # Add extension number attribute to the <enum> element
@@ -394,7 +394,7 @@ class Registry:
         # based on "structextends" tags in child structures
         for type in self.reg.findall('types/type'):
             parentStructs = type.get('structextends')
-            if (parentStructs != None):
+            if (parentStructs is not None):
                 for parent in parentStructs.split(','):
                     # self.gen.logMsg('diag', type.get('name'), 'extends', parent)
                     self.validextensionstructs[parent].append(type.get('name'))
@@ -443,7 +443,7 @@ class Registry:
         self.gen.logMsg('diag', '*** tagging type:', typename, '-> required =', required)
         # Get TypeInfo object for <type> tag corresponding to typename
         type = self.lookupElementInfo(typename, self.typedict)
-        if (type != None):
+        if (type is not None):
             if (required):
                 # Tag type dependencies in 'required' attributes as
                 # required. This DOES NOT un-tag dependencies in a <remove>
@@ -474,7 +474,7 @@ class Registry:
     def markEnumRequired(self, enumname, required):
         self.gen.logMsg('diag', '*** tagging enum:', enumname, '-> required =', required)
         enum = self.lookupElementInfo(enumname, self.enumdict)
-        if (enum != None):
+        if (enum is not None):
             enum.required = required
         else:
             self.gen.logMsg('warn', '*** enum:', enumname , 'IS NOT DEFINED')
@@ -495,7 +495,7 @@ class Registry:
             name = cmdElem.get('name')
             self.gen.logMsg('diag', '*** tagging command:', name, '-> required =', required)
             cmd = self.lookupElementInfo(name, self.cmddict)
-            if (cmd != None):
+            if (cmd is not None):
                 cmd.required = required
                 # Tag all parameter types of this command as required.
                 # This DOES NOT remove types of commands in a <remove>
@@ -555,7 +555,7 @@ class Registry:
     #   dictionary - of *Info objects - self.{type|enum|cmd}dict
     def generateFeature(self, fname, ftype, dictionary):
         f = self.lookupElementInfo(fname, dictionary)
-        if (f == None):
+        if (f is None):
             # No such feature. This is an error, but reported earlier
             self.gen.logMsg('diag', '*** No entry found for feature', fname,
                             'returning!')
@@ -599,7 +599,7 @@ class Registry:
             if (f.elem.get('category') == 'enum'):
                 self.gen.logMsg('diag', '*** Type', fname, 'is an enum group, so generate that instead')
                 group = self.lookupElementInfo(fname, self.groupdict)
-                if (group == None):
+                if (group is None):
                     # Unless this is tested for, it's probably fatal to call below
                     genProc = None
                     self.logMsg('warn', '*** NO MATCHING ENUM GROUP FOUND!!!')
@@ -674,7 +674,7 @@ class Registry:
                     # Matches API & version #s being generated. Mark for
                     # emission and add to the features[] list .
                     # @@ Could use 'declared' instead of 'emit'?
-                    fi.emit = (regEmitVersions.match(fi.version) != None)
+                    fi.emit = (regEmitVersions.match(fi.version) is not None)
                     features.append(fi)
                     if (not fi.emit):
                         self.gen.logMsg('diag', '*** NOT tagging feature api =', api,
@@ -716,7 +716,7 @@ class Registry:
             # the regexp specified in the generator options. This allows
             # forcing extensions into an interface even if they're not
             # tagged appropriately in the registry.
-            if (regAddExtensions.match(extName) != None):
+            if (regAddExtensions.match(extName) is not None):
                 self.gen.logMsg('diag', '*** Including extension',
                     extName, '(matches explicitly requested extensions to add)')
                 include = True
@@ -724,7 +724,7 @@ class Registry:
             # in generator options. This allows forcing removal of
             # extensions from an interface even if they're tagged that
             # way in the registry.
-            if (regRemoveExtensions.match(extName) != None):
+            if (regRemoveExtensions.match(extName) is not None):
                 self.gen.logMsg('diag', '*** Removing extension',
                     extName, '(matches explicitly requested extensions to remove)')
                 include = False
@@ -813,7 +813,7 @@ class Registry:
                         badGroup[group] = badGroup[group] +  1
             for param in cmd.findall('param'):
                 pname = param.find('name')
-                if (pname != None):
+                if (pname is not None):
                     pname = pname.text
                 else:
                     pname = type.get('name')

--- a/scripts/threading_generator.py
+++ b/scripts/threading_generator.py
@@ -305,7 +305,7 @@ class ThreadOutputGenerator(OutputGenerator):
             # this one, it may be necessary to suppress the ExtraProtect,
             # or move it below the 'for section...' loop.
             #write('// endFeature looking at self.featureExtraProtect', file=self.outFile)
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#ifdef', self.featureExtraProtect, file=self.outFile)
             #write('#define', self.featureName, '1', file=self.outFile)
             for section in self.TYPE_SECTIONS:
@@ -318,7 +318,7 @@ class ThreadOutputGenerator(OutputGenerator):
             if (self.sections['command']):
                 write('\n'.join(self.sections['command']), end=u'', file=self.outFile)
                 self.newline()
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#endif /*', self.featureExtraProtect, '*/', file=self.outFile)
             if (self.genOpts.protectFeature):
                 write('#endif /*', self.featureName, '*/', file=self.outFile)
@@ -399,10 +399,10 @@ class ThreadOutputGenerator(OutputGenerator):
             return
         finishthreadsafety = self.makeThreadUseBlock(cmdinfo.elem, 'finish')
         # record that the function will be intercepted
-        if (self.featureExtraProtect != None):
+        if (self.featureExtraProtect is not None):
             self.intercepts += [ '#ifdef %s' % self.featureExtraProtect ]
         self.intercepts += [ '    {"%s", (void*)%s},' % (name,name[2:]) ]
-        if (self.featureExtraProtect != None):
+        if (self.featureExtraProtect is not None):
             self.intercepts += [ '#endif' ]
 
         OutputGenerator.genCmd(self, cmdinfo, name)
@@ -423,9 +423,9 @@ class ThreadOutputGenerator(OutputGenerator):
             self.appendSection('command', '    VkLayerDispatchTable *pTable = my_data->device_dispatch_table;')
         # Declare result variable, if any.
         resulttype = cmdinfo.elem.find('proto/type')
-        if (resulttype != None and resulttype.text == 'void'):
+        if (resulttype is not None and resulttype.text == 'void'):
           resulttype = None
-        if (resulttype != None):
+        if (resulttype is not None):
             self.appendSection('command', '    ' + resulttype.text + ' result;')
             assignresult = 'result = '
         else:
@@ -445,7 +445,7 @@ class ThreadOutputGenerator(OutputGenerator):
         self.appendSection('command', '        finishMultiThread();')
         self.appendSection('command', '    }')
         # Return result variable, if any.
-        if (resulttype != None):
+        if (resulttype is not None):
             self.appendSection('command', '    return result;')
         self.appendSection('command', '}')
     #

--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -232,7 +232,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
         # Actually write the interface to the output file.
         if (self.emit):
             self.newline()
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#ifdef', self.featureExtraProtect, file=self.outFile)
             # Write the unique_objects code to the file
             if (self.sections['command']):
@@ -240,7 +240,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
                     write(self.genOpts.protectProto,
                           self.genOpts.protectProtoStr, file=self.outFile)
                 write('\n'.join(self.sections['command']), end=u'', file=self.outFile)
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('\n#endif //', self.featureExtraProtect, file=self.outFile)
             else:
                 self.newline()
@@ -262,10 +262,10 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
 
         if self.featureName != 'VK_VERSION_1_0':
             white_list_entry = []
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 white_list_entry += [ '#ifdef %s' % self.featureExtraProtect ]
             white_list_entry += [ '"%s"' % self.featureName ]
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 white_list_entry += [ '#endif' ]
             featureType = interface.get('type')
             if featureType == 'instance':
@@ -846,7 +846,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             if not api_decls and not api_pre and not api_post:
                 continue
             feature_extra_protect = cmd_protect_dict[api_call.name]
-            if (feature_extra_protect != None):
+            if (feature_extra_protect is not None):
                 self.appendSection('command', '')
                 self.appendSection('command', '#ifdef '+ feature_extra_protect)
                 self.intercepts += [ '#ifdef %s' % feature_extra_protect ]
@@ -866,9 +866,9 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
                 self.appendSection('command', '    layer_data *dev_data = GetLayerDataPtr(get_dispatch_key('+dispatchable_name+'), layer_data_map);')
             # Handle return values, if any
             resulttype = cmdinfo.elem.find('proto/type')
-            if (resulttype != None and resulttype.text == 'void'):
+            if (resulttype is not None and resulttype.text == 'void'):
               resulttype = None
-            if (resulttype != None):
+            if (resulttype is not None):
                 assignresult = resulttype.text + ' result = '
             else:
                 assignresult = ''
@@ -897,9 +897,9 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             # And add the post-API-call codegen
             self.appendSection('command', "\n".join(str(api_post).rstrip().split("\n")))
             # Handle the return result variable, if any
-            if (resulttype != None):
+            if (resulttype is not None):
                 self.appendSection('command', '    return result;')
             self.appendSection('command', '}')
-            if (feature_extra_protect != None):
+            if (feature_extra_protect is not None):
                 self.appendSection('command', '#endif // '+ feature_extra_protect)
                 self.intercepts += [ '#endif' ]


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations