### PR TITLE
Update init_resources utility to match glslang defaults.

### DIFF
--- a/API-Samples/utils/util.cpp
+++ b/API-Samples/utils/util.cpp
@@ -400,6 +400,15 @@ void init_resources(TBuiltInResource &Resources) {
     Resources.maxCullDistances = 8;
     Resources.maxCombinedClipAndCullDistances = 8;
     Resources.maxSamples = 4;
+    Resources.maxMeshOutputVerticesNV = 256;
+    Resources.maxMeshOutputPrimitivesNV = 512;
+    Resources.maxMeshWorkGroupSizeX_NV = 32;
+    Resources.maxMeshWorkGroupSizeY_NV = 1;
+    Resources.maxMeshWorkGroupSizeZ_NV = 1;
+    Resources.maxTaskWorkGroupSizeX_NV = 32;
+    Resources.maxTaskWorkGroupSizeY_NV = 1;
+    Resources.maxTaskWorkGroupSizeZ_NV = 1;
+    Resources.maxMeshViewCountNV = 4;
     Resources.limits.nonInductiveForLoops = 1;
     Resources.limits.whileLoops = 1;
     Resources.limits.doWhileLoops = 1;


### PR DESCRIPTION
When using an AMD card I was getting some validation erros from the `GLSLtoSPV` utility function. I updated the `init_resources` function to match `const TBuiltInResource DefaultTBuiltInResource` variable in the [glslang repo](https://github.com/KhronosGroup/glslang/blob/master/StandAlone/ResourceLimits.cpp).

That link should take you to the file I took the values from (**ResourceLimits.cpp**). Adding these defaults fixed the validation errors for me. Here is the error:

> Unable to parse built-ins
> ERROR: 0:3: '' :  syntax error, unexpected CONST, expecting COMMA or SEMICOLON
> INTERNAL ERROR: Unable to parse built-ins
> 
> const int  gl_MaxVertexAttribs = 64;const int  gl_MaxVertexTextureImageUnits = 32;const int  gl_MaxCombinedTextureImageUnits = 80;const int  gl_MaxTextureImageUnits = 32;const int  gl_MaxDrawBuffers = 32;const int  gl_MaxLights = 32;const int  gl_MaxClipPlanes = 6;const int  gl_MaxTextureUnits = 32;const int  gl_MaxTextureCoords = 32;const int  gl_MaxVertexUniformComponents = 4096;const int  gl_MaxVaryingFloats = 64;const int  gl_MaxFragmentUniformComponents = 4096;const int gl_MaxClipDistances = 8;const int gl_MaxVaryingComponents = 60;const mediump int  gl_MinProgramTexelOffset = -8;const mediump int  gl_MaxProgramTexelOffset = 7;const int gl_MaxGeometryInputComponents = 64;const int gl_MaxGeometryOutputComponents = 128;const int gl_MaxGeometryTextureImageUnits = 16;const int gl_MaxGeometryOutputVertices = 256;const int gl_MaxGeometryTotalOutputComponents = 1024;const int gl_MaxGeometryUniformComponents = 1024;const int gl_MaxGeometryVaryingComponents = 64;const int gl_MaxVertexOutputComponents = 64;const int gl_MaxFragmentInputComponents = 128;const int gl_MaxTessControlInputComponents = 128;const int gl_MaxTessControlOutputComponents = 128;const int gl_MaxTessControlTextureImageUnits = 16;const int gl_MaxTessControlUniformComponents = 1024;const int gl_MaxTessControlTotalOutputComponents = 4096;const int gl_MaxTessEvaluationInputComponents = 128;const int gl_MaxTessEvaluationOutputComponents = 128;const int gl_MaxTessEvaluationTextureImageUnits = 16;const int gl_MaxTessEvaluationUniformComponents = 1024;const int gl_MaxTessPatchComponents = 120;const int gl_MaxTessGenLevel = 64;const int gl_MaxPatchVertices = 32;const int gl_MaxViewports = 16;const int gl_MaxCombinedImageUnitsAndFragmentOutputs = 8;const int gl_MaxImageSamples = 0;const int gl_MaxTessControlImageUniforms = 0;const int gl_MaxTessEvaluationImageUniforms = 0;const int gl_MaxGeometryImageUniforms = 0;const int gl_MaxTransformFeedbackBuffers = 4;const int gl_MaxTransformFeedbackInterleavedComponents = 64;const int gl_MaxImageUnits = 8;const int gl_MaxCombinedShaderOutputResources = 8;const int gl_MaxVertexImageUniforms = 0;const int gl_MaxFragmentImageUniforms = 8;const int gl_MaxCombinedImageUniforms = 8;const int gl_MaxVertexAtomicCounters = 0;const int gl_MaxFragmentAtomicCounters = 8;const int gl_MaxCombinedAtomicCounters = 8;const int gl_MaxAtomicCounterBindings = 1;const int gl_MaxVertexAtomicCounterBuffers = 0;const int gl_MaxFragmentAtomicCounterBuffers = 1;const int gl_MaxCombinedAtomicCounterBuffers = 1;const int gl_MaxAtomicCounterBufferSize = 16384;const int gl_MaxTessControlAtomicCounters = 0;const int gl_MaxTessEvaluationAtomicCounters = 0;const int gl_MaxGeometryAtomicCounters = 0;const int gl_MaxTessControlAtomicCounterBuffers = 0;const int gl_MaxTessEvaluationAtomicCounterBuffers = 0;const int gl_MaxGeometryAtomicCounterBuffers = 0;
> const ivec3 gl_MaxComputeWorkGroupCount = ivec3(65535,65535,65535);const ivec3 gl_MaxComputeWorkGroupSize = ivec3(1024,1024,64);const int gl_MaxComputeUniformComponents = 1024;const int gl_MaxComputeTextureImageUnits = 16;const int gl_MaxComputeImageUniforms = 8;const int gl_MaxComputeAtomicCounters = 8;const int gl_MaxComputeAtomicCounterBuffers = 1;
> const int gl_MaxCullDistances = 8;const int gl_MaxCombinedClipAndCullDistances = 8;const int gl_MaxSamples = 4;const int gl_SIMDGroupSizeAMD = 64;const int gl_MaxMeshOutputVerticesNV = -858993460;const int gl_MaxMeshOutputPrimitivesNV = -858993460;const ivec3 gl_MaxMeshWorkGroupSizeNV = ivec3(-858993460,-858993460,-858993460)const ivec3 gl_MaxTaskWorkGroupSizeNV = ivec3(-858993460,-858993460,-858993460)const int gl_MaxMeshViewCountNV = -858993460;

-  **Note:** This was not causing the shader compilation to fail, but was spamming the console with large validation errors. I figured setting these values to the same defaults as the original [repo](https://github.com/KhronosGroup/glslang/blob/master/StandAlone/ResourceLimits.cpp) would be harmless. I did not investigate this much further after the validation error went away.