### PR TITLE
samples: Fix 1.1 samples for future versions

### DIFF
--- a/API-Samples/16-vulkan_1_1/16-vulkan_1_1.cpp
+++ b/API-Samples/16-vulkan_1_1/16-vulkan_1_1.cpp
@@ -126,7 +126,7 @@ int sample_main(int argc, char *argv[]) {
     using_version_string += ".";
     using_version_string += std::to_string(using_minor_version);
 
-    if (using_minor_version != desired_minor_version) {
+    if (using_minor_version < desired_minor_version) {
         std::cout << "Determined that this system can only use Vulkan API version " << using_version_string
                   << " instead of desired version " << desired_version_string << std::endl;
     } else {

--- a/API-Samples/vulkan_1_1_flexible/vulkan_1_1_flexible.cpp
+++ b/API-Samples/vulkan_1_1_flexible/vulkan_1_1_flexible.cpp
@@ -129,7 +129,7 @@ int sample_main(int argc, char *argv[]) {
     using_version_string += ".";
     using_version_string += std::to_string(using_minor_version);
 
-    if (using_minor_version != desired_minor_version) {
+    if (using_minor_version < desired_minor_version) {
         std::cout << "Determined that this system can only use Vulkan API version " << using_version_string
                   << " instead of desired version " << desired_version_string << std::endl;
     } else {


### PR DESCRIPTION
The 1.1 detection sample did not allow for the drivers/loader
to support > 1.1 (i.e. 1.2 or greater).
I caught this while re-evaluating our 1.1 detection logic.