### PR TITLE
build: Fix python3 warning

### DIFF
--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -33,12 +33,13 @@ startTime = None
 
 def startTimer(timeit):
     global startTime
-    startTime = time.clock()
+    if timeit:
+        startTime = time.process_time()
 
 def endTimer(timeit, msg):
     global startTime
-    endTime = time.clock()
-    if (timeit):
+    if timeit:
+        endTime = time.process_time()
         write(msg, endTime - startTime, file=sys.stderr)
         startTime = None
 


### PR DESCRIPTION
Python 3.8 will deprecate time.clock. Replace it and also fix
the code to only calcualte times when needd.