### PR TITLE
add cmake version reporting to appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,6 +30,7 @@ before_build:
   - echo Generating CMake files for %PLATFORM%
   - mkdir build
   - cd build
+  - cmake --version
   - cmake -A %PLATFORM% -C../external/helper.cmake --config %CONFIGURATION% ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 


### PR DESCRIPTION
This will allow us to check our build logs to determine the exact
CMake version used with that build.