### PR TITLE
build: Update cmake_minimum_required(VERSION 3.12.4)

### DIFF
--- a/API-Samples/CMakeLists.txt
+++ b/API-Samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.4)
 
 # If ANDROID is ON, turn on cross-compiling for it
 if(ANDROID)

--- a/API-Samples/android/CMakeLists.txt
+++ b/API-Samples/android/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.12.4)
 get_filename_component(SHADERC_SRC
                        ${ANDROID_NDK}/sources/third_party/shaderc
                        ABSOLUTE)

--- a/BUILD.md
+++ b/BUILD.md
@@ -170,7 +170,7 @@ generate the native platform files.
     - [2017](https://www.visualstudio.com/vs/downloads/)
   - The Community Edition of each of the above versions is sufficient, as
     well as any more capable edition.
-- CMake: Continuous integration tools use [CMake 3.12.2](https://github.com/Kitware/CMake/releases/tag/v3.12.2) for Windows
+- CMake [version 3.12.4](https://github.com/Kitware/CMake/releases/tag/v3.12.4) or greater is required.
   - Use the installer option to add CMake to the system PATH
 - Git Client Support
   - [Git for Windows](http://git-scm.com/download/win) is a popular solution
@@ -261,7 +261,7 @@ in the build folder. You may select "Debug" or "Release" from the Solution
 Configurations drop-down list. Start a build by selecting the Build->Build
 Solution menu item.
 
-The continuous integration tools use [CMake 3.12.4](https://github.com/Kitware/CMake/releases/tag/v3.12.4) for Linux
+CMake [version 3.12.4](https://github.com/Kitware/CMake/releases/tag/v3.12.4) or greater is required.
 
 ## Building On Linux
 
@@ -275,7 +275,7 @@ repository to other Linux distributions.
 
 #### Required Package List
 
-    sudo apt-get install git cmake build-essential libx11-xcb-dev \
+    sudo apt-get install git build-essential libx11-xcb-dev \
         libxkbcommon-dev libwayland-dev libxrandr-dev
 
 ### Linux Build

--- a/CMakeLists-SDK.txt
+++ b/CMakeLists-SDK.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.4)
 project (VULKAN_SAMPLES)
 # set (CMAKE_VERBOSE_MAKEFILE 1)
 set(API_NAME "Vulkan" CACHE STRING "API name to use when building")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # The name of our project is "VULKAN_SAMPLES". CMakeLists files in this project can
 # refer to the root source directory of the project as ${VULKAN_SOURCE_DIR} and
 # to the root binary directory of the project as ${VULKAN_BINARY_DIR}.
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.4)
 project (VULKAN_SAMPLES)
 # set (CMAKE_VERBOSE_MAKEFILE 1)
 

--- a/Layer-Samples/Overlay/CMakeLists.txt
+++ b/Layer-Samples/Overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.4)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)

--- a/Sample-Programs/Hologram/android/CMakeLists.txt
+++ b/Sample-Programs/Hologram/android/CMakeLists.txt
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
+cmake_minimum_required(VERSION 3.12.4)
 project(Hologram)
-cmake_minimum_required(VERSION 3.4.1)
 
 get_filename_component(samplesDir "${CMAKE_SOURCE_DIR}/../../.." ABSOLUTE)
 set(hologramDir "${samplesDir}/Sample-Programs/Hologram")


### PR DESCRIPTION
Update both CMakeLists.txt files and documents to the new required CMake version.
This PR will not be merged to master until the CI systems are updated.

Also, cmake_minimum_required() must occur before the project() command,
see https://cmake.org/cmake/help/latest/command/project.html
