### PR TITLE
Updates to conversion of GLSL to SPIR-V under MoltenVK.

### DIFF
--- a/API-Samples/utils/util.cpp
+++ b/API-Samples/utils/util.cpp
@@ -279,28 +279,28 @@ void init_glslang() {}
 void finalize_glslang() {}
 
 bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spirv) {
-    MVKShaderStage shaderStage;
+    MVKGLSLConversionShaderStage shaderStage;
     switch (shader_type) {
         case VK_SHADER_STAGE_VERTEX_BIT:
-            shaderStage = kMVKShaderStageVertex;
+            shaderStage = kMVKGLSLConversionShaderStageVertex;
             break;
         case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
-            shaderStage = kMVKShaderStageTessControl;
+            shaderStage = kMVKGLSLConversionShaderStageTessControl;
             break;
         case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
-            shaderStage = kMVKShaderStageTessEval;
+            shaderStage = kMVKGLSLConversionShaderStageTessEval;
             break;
         case VK_SHADER_STAGE_GEOMETRY_BIT:
-            shaderStage = kMVKShaderStageGeometry;
+            shaderStage = kMVKGLSLConversionShaderStageGeometry;
             break;
         case VK_SHADER_STAGE_FRAGMENT_BIT:
-            shaderStage = kMVKShaderStageFragment;
+            shaderStage = kMVKGLSLConversionShaderStageFragment;
             break;
         case VK_SHADER_STAGE_COMPUTE_BIT:
-            shaderStage = kMVKShaderStageCompute;
+            shaderStage = kMVKGLSLConversionShaderStageCompute;
             break;
         default:
-            shaderStage = kMVKShaderStageAuto;
+            shaderStage = kMVKGLSLConversionShaderStageAuto;
             break;
     }
 


### PR DESCRIPTION
APISamples demo uses updated MoltenVK shader stage enumeration.
Hologram demo under MoltenVK now loads SPIR-V directly, in conformance with other platforms.