### PR TITLE
cmake: Use CMake 3.10.2 for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ os:
 environment:
   PYTHON_PATH: "C:/Python35"
   PYTHON_PACKAGE_PATH: "C:/Python35/Scripts"
-  CMAKE_URL: "https://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip"
+  CMAKE_URL: "http://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip"
 
 branches:
   only:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,15 +17,16 @@ os:
 environment:
   PYTHON_PATH: "C:/Python35"
   PYTHON_PACKAGE_PATH: "C:/Python35/Scripts"
+  CMAKE_URL: "https://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip"
 
 branches:
   only:
     - master
 
-# Install desired CMake version 3.10.2 before any other building
 install:
-  - choco upgrade cmake --version 3.10.2
-  - set path=C:\Program Files\CMake\bin;%path%
+  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+  - 7z x cmake.zip -oC:\cmake > nul
+  - set path=C:\cmake\bin;%path%
   - cmake --version
 
 before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,12 @@ branches:
   only:
     - master
 
+# Install desired CMake version 3.10.2 before any other building
+install:
+  - choco upgrade cmake --version 3.10.2
+  - set path=C:\Program Files\CMake\bin;%path%
+  - cmake --version
+
 before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
   - echo Starting build for %APPVEYOR_REPO_NAME%
@@ -30,7 +36,6 @@ before_build:
   - echo Generating CMake files for %PLATFORM%
   - mkdir build
   - cd build
-  - cmake --version
   - cmake -A %PLATFORM% -C../external/helper.cmake --config %CONFIGURATION% ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,21 @@ cache: ccache
 # The default action for Travis-CI is to continue running even if a command fails.
 # See https://github.com/travis-ci/travis-ci/issues/1066.
 # Use the YAML block scalar header (|) to allow easier multiline script coding.
+# Install the desired CMake before running update_deps.py
 
 before_install:
   - set -e
+  - CMAKE_VERSION=3.10.2
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+      echo CMAKE_URL=${CMAKE_URL}
+      mkdir cmake-${CMAKE_VERSION} && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake-${CMAKE_VERSION}
+      export PATH=${PWD}/cmake-${CMAKE_VERSION}/bin:${PATH}
+    else
+      brew install cmake || brew upgrade cmake
+    fi
+    cmake --version
   - |
     if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
         # Add an option to update dependencies from master
@@ -92,7 +104,6 @@ script:
       # Build VulkanSamples
       mkdir build
       cd build
-      cmake --version
       cmake -C../external/helper.cmake ..
       make -j $core_count
       cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,6 @@ script:
 notifications:
   email:
     recipients:
-      - karl@lunarg.com
       - cnorthrop@google.com
       - tobine@google.com
       - chrisforbes@google.com


### PR DESCRIPTION
These changes ensure that the Travis and AppVeyor
builds use a known version of CMake.