### PR TITLE
Rename variable

### DIFF
--- a/API-Samples/08-init_pipeline_layout/08-init_pipeline_layout.cpp
+++ b/API-Samples/08-init_pipeline_layout/08-init_pipeline_layout.cpp
@@ -68,15 +68,15 @@ int sample_main(int argc, char *argv[]) {
     assert(res == VK_SUCCESS);
 
     /* Now use the descriptor layout to create a pipeline layout */
-    VkPipelineLayoutCreateInfo pPipelineLayoutCreateInfo = {};
-    pPipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    pPipelineLayoutCreateInfo.pNext = NULL;
-    pPipelineLayoutCreateInfo.pushConstantRangeCount = 0;
-    pPipelineLayoutCreateInfo.pPushConstantRanges = NULL;
-    pPipelineLayoutCreateInfo.setLayoutCount = NUM_DESCRIPTOR_SETS;
-    pPipelineLayoutCreateInfo.pSetLayouts = info.desc_layout.data();
+    VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = {};
+    pipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pipelineLayoutCreateInfo.pNext = NULL;
+    pipelineLayoutCreateInfo.pushConstantRangeCount = 0;
+    pipelineLayoutCreateInfo.pPushConstantRanges = NULL;
+    pipelineLayoutCreateInfo.setLayoutCount = NUM_DESCRIPTOR_SETS;
+    pipelineLayoutCreateInfo.pSetLayouts = info.desc_layout.data();
 
-    res = vkCreatePipelineLayout(info.device, &pPipelineLayoutCreateInfo, NULL, &info.pipeline_layout);
+    res = vkCreatePipelineLayout(info.device, &pipelineLayoutCreateInfo, NULL, &info.pipeline_layout);
     assert(res == VK_SUCCESS);
     /* VULKAN_KEY_END */
 

--- a/API-Samples/Tutorial/markdown/08-init_pipeline_layout.md
+++ b/API-Samples/Tutorial/markdown/08-init_pipeline_layout.md
@@ -97,15 +97,15 @@ As with the descriptor sets, you are just defining the layout.
 The actual descriptor set is allocated and
 filled in with the uniform buffer reference later.
 
-    VkPipelineLayoutCreateInfo pPipelineLayoutCreateInfo = {};
-    pPipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    pPipelineLayoutCreateInfo.pNext = NULL;
-    pPipelineLayoutCreateInfo.pushConstantRangeCount = 0;
-    pPipelineLayoutCreateInfo.pPushConstantRanges = NULL;
-    pPipelineLayoutCreateInfo.setLayoutCount = NUM_DESCRIPTOR_SETS;
-    pPipelineLayoutCreateInfo.pSetLayouts = info.desc_layout.data();
+    VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = {};
+    pipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pipelineLayoutCreateInfo.pNext = NULL;
+    pipelineLayoutCreateInfo.pushConstantRangeCount = 0;
+    pipelineLayoutCreateInfo.pPushConstantRanges = NULL;
+    pipelineLayoutCreateInfo.setLayoutCount = NUM_DESCRIPTOR_SETS;
+    pipelineLayoutCreateInfo.pSetLayouts = info.desc_layout.data();
 
-    res = vkCreatePipelineLayout(info.device, &pPipelineLayoutCreateInfo, NULL,
+    res = vkCreatePipelineLayout(info.device, &pipelineLayoutCreateInfo, NULL,
                                  &info.pipeline_layout);
 
 You will use the pipeline layout later to create the graphics pipeline.


### PR DESCRIPTION
Rename variable from `pPipelineLayoutCreateInfo` to `pipelineLayoutCreateInfo` since this variable is a structure rather than a pointer.