### PR TITLE
Retry for Android Studio/Gradle 3.4.1 build

### DIFF
--- a/API-Samples/android/build.gradle
+++ b/API-Samples/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/API-Samples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/API-Samples/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 10 16:22:56 PDT 2017
+#Mon Jun 03 18:51:35 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/API-Samples/android/project_template/build.gradle
+++ b/API-Samples/android/project_template/build.gradle
@@ -14,21 +14,7 @@
 
 apply plugin: 'com.android.application'
 
-def ndkDir
-if (project.rootProject.file('local.properties').exists()) {
-    Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    ndkDir = properties.getProperty('ndk.dir')
-}
-if (!ndkDir) {
-    ndkDir=System.getenv("ANDROID_NDK_HOME")
-}
-
-if(!ndkDir || ndkDir.empty) {
-   throw new GradleException('Environment Variable ANDROID_NDK_HOME for NDK path need to be setup')
-}
-
-
+def ndkDir=android.ndkDirectory.path
 def stlType = 'c++_static'
 
 android {


### PR DESCRIPTION
2 minor changes:

-  Update gradle plugin version to 3.4.1
-  Use new way to retrieve ndkDir: future Android Studio 3.5 compliant when side-by-side ndk arrives

Tested on Linux
