### PR TITLE
Fix the loop count in `05-init_swapchain` sample code

### DIFF
--- a/API-Samples/05-init_swapchain/05-init_swapchain.cpp
+++ b/API-Samples/05-init_swapchain/05-init_swapchain.cpp
@@ -213,7 +213,7 @@ int sample_main(int argc, char *argv[]) {
         VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR,
         VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR,
     };
-    for (uint32_t i = 0; i < sizeof(compositeAlphaFlags); i++) {
+    for (uint32_t i = 0; i < sizeof(compositeAlphaFlags) / sizeof(compositeAlphaFlags[0]); i++) {
         if (surfCapabilities.supportedCompositeAlpha & compositeAlphaFlags[i]) {
             compositeAlpha = compositeAlphaFlags[i];
             break;


### PR DESCRIPTION
The value of `sizeof(compositeAlphaFlags)` is 16 (size in bytes) rather than the expected element count of 4. The expected element count equals the size of the array divided by the size of the element in the array.