### PR TITLE
API Samples use VK_EXT_metal_surface extension

### DIFF
--- a/API-Samples/memory_barriers/memory_barriers.cpp
+++ b/API-Samples/memory_barriers/memory_barriers.cpp
@@ -34,7 +34,7 @@ Use memory barriers to update texture
 #include <assert.h>
 #include <string.h>
 #include <cstdlib>
-#include <cube_data.h>
+#include "cube_data.h"
 
 // Using OpenGL based glm, so Y is upside down between OpenGL and Vulkan
 
@@ -100,10 +100,8 @@ int sample_main(int argc, char **argv) {
     info.instance_extension_names.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #elif __ANDROID__
     info.instance_extension_names.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_IOS_MVK)
-    info.instance_extension_names.push_back(VK_MVK_IOS_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_MACOS_MVK)
-    info.instance_extension_names.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
+    info.instance_extension_names.push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
     info.instance_extension_names.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
 #else

--- a/API-Samples/occlusion_query/occlusion_query.cpp
+++ b/API-Samples/occlusion_query/occlusion_query.cpp
@@ -86,10 +86,8 @@ int sample_main(int argc, char *argv[]) {
     info.instance_extension_names.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #elif defined(__ANDROID__)
     info.instance_extension_names.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_IOS_MVK)
-    info.instance_extension_names.push_back(VK_MVK_IOS_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_MACOS_MVK)
-    info.instance_extension_names.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
+    info.instance_extension_names.push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
     info.instance_extension_names.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
 #else

--- a/API-Samples/utils/util.cpp
+++ b/API-Samples/utils/util.cpp
@@ -59,7 +59,7 @@ static android_app *Android_application = nullptr;
 
 using namespace std;
 
-#if !(defined(__ANDROID__) || defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
+#if !(defined(__ANDROID__) || defined(VK_USE_PLATFORM_METAL_EXT))
 // Android, iOS, and macOS: main() implemented externally to allow access to Objective-C components
 int main(int argc, char **argv) { return sample_main(argc, argv); }
 #endif
@@ -86,7 +86,7 @@ string get_file_name(const string &s) {
     return ("");
 }
 
-#if !(defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
+#if !defined(VK_USE_PLATFORM_METAL_EXT)
 // iOS & macOS: get_base_data_dir() implemented externally to allow access to Objective-C components
 std::string get_base_data_dir() {
 #ifdef __ANDROID__
@@ -313,7 +313,7 @@ bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std
     return wasConverted;
 }
 
-#else  // not IOS OR macOS
+#else  // not MVK iOS/macOS
 
 #ifndef __ANDROID__
 void init_resources(TBuiltInResource &Resources) {

--- a/API-Samples/utils/util.hpp
+++ b/API-Samples/utils/util.hpp
@@ -147,8 +147,8 @@ struct sample_info {
     HINSTANCE connection;        // hInstance - Windows Instance
     char name[APP_NAME_STR_LEN]; // Name to put on the window/icon
     HWND window;                 // hWnd - window handle
-#elif (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK))
-	void* window;
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
+    void *caMetalLayer;
 #elif defined(__ANDROID__)
     PFN_vkCreateAndroidSurfaceKHR fpCreateAndroidSurfaceKHR;
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)

--- a/API-Samples/utils/util_init.cpp
+++ b/API-Samples/utils/util_init.cpp
@@ -172,10 +172,8 @@ void init_instance_extension_names(struct sample_info &info) {
     info.instance_extension_names.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
 #elif defined(_WIN32)
     info.instance_extension_names.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_IOS_MVK)
-    info.instance_extension_names.push_back(VK_MVK_IOS_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_MACOS_MVK)
-    info.instance_extension_names.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
+    info.instance_extension_names.push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
     info.instance_extension_names.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
 #else
@@ -487,13 +485,11 @@ void destroy_window(struct sample_info &info) {
     DestroyWindow(info.window);
 }
 
-#elif defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK)
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
 
 // iOS & macOS: init_window() implemented externally to allow access to Objective-C components
 
-void destroy_window(struct sample_info &info) {
-	info.window = NULL;
-}
+void destroy_window(struct sample_info &info) { info.caMetalLayer = NULL; }
 
 #elif defined(__ANDROID__)
 // Android implementation.
@@ -716,20 +712,13 @@ void init_swapchain_extension(struct sample_info &info) {
     createInfo.flags = 0;
     createInfo.window = AndroidGetApplicationWindow();
     res = info.fpCreateAndroidSurfaceKHR(info.inst, &createInfo, nullptr, &info.surface);
-#elif defined(VK_USE_PLATFORM_IOS_MVK)
-    VkIOSSurfaceCreateInfoMVK createInfo = {};
-    createInfo.sType = VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK;
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
+    VkMetalSurfaceCreateInfoEXT createInfo = {};
+    createInfo.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
     createInfo.pNext = NULL;
     createInfo.flags = 0;
-    createInfo.pView = info.window;
-    res = vkCreateIOSSurfaceMVK(info.inst, &createInfo, NULL, &info.surface);
-#elif defined(VK_USE_PLATFORM_MACOS_MVK)
-    VkMacOSSurfaceCreateInfoMVK createInfo = {};
-    createInfo.sType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK;
-    createInfo.pNext = NULL;
-    createInfo.flags = 0;
-    createInfo.pView = info.window;
-    res = vkCreateMacOSSurfaceMVK(info.inst, &createInfo, NULL, &info.surface);
+    createInfo.pLayer = info.caMetalLayer;
+    res = vkCreateMetalSurfaceEXT(info.inst, &createInfo, NULL, &info.surface);
 #elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
     VkWaylandSurfaceCreateInfoKHR createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;


### PR DESCRIPTION
API Samples replace use of VK_MVK_macos_surface & VK_MVK_ios_surface extensions with VK_EXT_metal_surface extension.

memory_barriers.cpp include cube_data.h using quotes
instead of angles, to align with other samples.