### PR TITLE
samples: Move from standard_validation to KHRONOS

### DIFF
--- a/API-Samples/enable_validation_with_callback/enable_validation_with_callback.cpp
+++ b/API-Samples/enable_validation_with_callback/enable_validation_with_callback.cpp
@@ -63,9 +63,7 @@ int sample_main(int argc, char *argv[]) {
 
     /* VULKAN_KEY_START */
 
-    /* Use standard_validation meta layer that enables all
-     * recommended validation layers
-     */
+    /* Enable validation*/
     info.instance_layer_names.push_back("VK_LAYER_KHRONOS_validation");
     if (!demo_check_layers(info.instance_layer_properties, info.instance_layer_names)) {
         if (!demo_check_layers(info.instance_layer_properties, info.instance_layer_names)) {

--- a/API-Samples/validation_cache/validation_cache.cpp
+++ b/API-Samples/validation_cache/validation_cache.cpp
@@ -97,7 +97,7 @@ int sample_main(int argc, char *argv[]) {
     init_device_extension_names(info);
     // The VK_EXT_validation_cache extension is implemented by the validation layers, so
     // they must be enabled in order to use it.
-    info.instance_layer_names.push_back("VK_LAYER_LUNARG_standard_validation");
+    info.instance_layer_names.push_back("VK_LAYER_KHRONOS_validation");
     if (!demo_check_layers(info.instance_layer_properties, info.instance_layer_names)) {
         std::cout << "Set the environment variable VK_LAYER_PATH to point to the location of your layers" << std::endl;
         exit(1);

--- a/Sample-Programs/Hologram/Shell.cpp
+++ b/Sample-Programs/Hologram/Shell.cpp
@@ -32,7 +32,7 @@ Shell::Shell(Game &game)
 
     // require "standard" validation layers
     if (settings_.validate) {
-        instance_layers_.push_back("VK_LAYER_LUNARG_standard_validation");
+        instance_layers_.push_back("VK_LAYER_KHRONOS_validation");
         instance_extensions_.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
     }
 }

--- a/Sample-Programs/Hologram/ShellWayland.cpp
+++ b/Sample-Programs/Hologram/ShellWayland.cpp
@@ -188,7 +188,7 @@ void ShellWayland::registry_handle_global_remove(void *data, wl_registry *regist
 const wl_registry_listener ShellWayland::registry_listener = {registry_handle_global, registry_handle_global_remove};
 
 ShellWayland::ShellWayland(Game &game) : Shell(game) {
-    if (game.settings().validate) instance_layers_.push_back("VK_LAYER_LUNARG_standard_validation");
+    if (game.settings().validate) instance_layers_.push_back("VK_LAYER_KHRONOS_validation");
     instance_extensions_.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
 
     init_connection();


### PR DESCRIPTION
VK_LAYER_LUNARG_standard_validation has been replaced by VK_LAYER_KHRONOS_validation