### PR TITLE
Fix renderpass to preserve image

### DIFF
--- a/API-Samples/memory_barriers/memory_barriers.cpp
+++ b/API-Samples/memory_barriers/memory_barriers.cpp
@@ -126,7 +126,7 @@ int sample_main(int argc, char **argv) {
     init_texture(info, nullptr, VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_FORMAT_FEATURE_BLIT_DST_BIT);
     init_uniform_buffer(info);
     init_descriptor_and_pipeline_layouts(info, true);
-    init_renderpass(info, DEPTH_PRESENT, false, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    init_renderpass(info, DEPTH_PRESENT, false, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     init_shaders(info, vertShaderText, fragShaderText);
     init_framebuffers(info, DEPTH_PRESENT);
     init_vertex_buffer(info, vb_Data, sizeof(vb_Data), sizeof(vb_Data[0]), true);
@@ -172,6 +172,10 @@ int sample_main(int argc, char **argv) {
     // we will use the same renderpass multiple times in the frame
     vkCmdClearColorImage(info.cmd, info.buffers[info.current_buffer].image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, clear_color, 1,
                          &srRange);
+
+    set_image_layout(info, info.buffers[info.current_buffer].image, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                     VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
 
     VkRenderPassBeginInfo rp_begin;
     rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;

--- a/API-Samples/multithreaded_command_buffers/multithreaded_command_buffers.cpp
+++ b/API-Samples/multithreaded_command_buffers/multithreaded_command_buffers.cpp
@@ -134,11 +134,12 @@ int sample_main(int argc, char *argv[]) {
 
     res = vkCreatePipelineLayout(info.device, &pPipelineLayoutCreateInfo, NULL, &info.pipeline_layout);
     assert(res == VK_SUCCESS);
-    init_renderpass(info, depthPresent, false, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);  // Can't clear in
-                                                                                           // renderpass
-                                                                                           // load because
-                                                                                           // we re-use
-                                                                                           // pipeline
+    init_renderpass(info, depthPresent, false, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                    VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);  // Can't clear in
+                                                                // renderpass
+                                                                // load because
+                                                                // we re-use
+                                                                // pipeline
     init_shaders(info, vertShaderText, fragShaderText);
     init_framebuffers(info, depthPresent);
 

--- a/API-Samples/utils/util_init.cpp
+++ b/API-Samples/utils/util_init.cpp
@@ -1145,7 +1145,8 @@ void init_descriptor_and_pipeline_layouts(struct sample_info &info, bool use_tex
     assert(res == VK_SUCCESS);
 }
 
-void init_renderpass(struct sample_info &info, bool include_depth, bool clear, VkImageLayout finalLayout) {
+void init_renderpass(struct sample_info &info, bool include_depth, bool clear, VkImageLayout finalLayout,
+                     VkImageLayout initialLayout) {
     /* DEPENDS on init_swap_chain() and init_depth_buffer() */
 
     VkResult U_ASSERT_ONLY res;
@@ -1157,7 +1158,7 @@ void init_renderpass(struct sample_info &info, bool include_depth, bool clear, V
     attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachments[0].initialLayout = initialLayout;
     attachments[0].finalLayout = finalLayout;
     attachments[0].flags = 0;
 

--- a/API-Samples/utils/util_init.hpp
+++ b/API-Samples/utils/util_init.hpp
@@ -64,9 +64,9 @@ void init_depth_buffer(struct sample_info &info);
 void init_uniform_buffer(struct sample_info &info);
 void init_descriptor_and_pipeline_layouts(struct sample_info &info, bool use_texture,
                                           VkDescriptorSetLayoutCreateFlags descSetLayoutCreateFlags = 0);
-void init_renderpass(
-    struct sample_info &info, bool include_depth, bool clear = true,
-    VkImageLayout finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+void init_renderpass(struct sample_info &info, bool include_depth, bool clear = true,
+                     VkImageLayout finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+                     VkImageLayout initialLayout = VK_IMAGE_LAYOUT_UNDEFINED);
 void init_vertex_buffer(struct sample_info &info, const void *vertexData,
                         uint32_t dataSize, uint32_t dataStride,
                         bool use_texture);


### PR DESCRIPTION
Renderpass initial layout was UNDEFINED allowing pixel from previous draws to be trashed.  