### PR TITLE
Update Android build with gradle plugin version 4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
           - build-tools-26.0.2
           - android-26
           - extra
-      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_ABI=armeabi-v7a
+      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_ABI=arm64-v8a
     # Linux GCC debug build.
     - os: linux
       compiler: gcc
@@ -68,10 +68,17 @@ before_install:
       export ARCH=`uname -m`
       wget http://dl.google.com/android/repository/android-ndk-r15c-linux-${ARCH}.zip
       unzip -u -q android-ndk-r15c-linux-${ARCH}.zip
-      export ANDROID_NDK_HOME=`pwd`/android-ndk-r15c
+      # export ANDROID_NDK_HOME=`pwd`/android-ndk-r15c
       export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
       export PATH="$ANDROID_NDK_HOME:$PATH"
       pushd android-ndk-r15c
+
+      ndk_version=$(grep ndkVersion API-Samples/android/project_template/build.gradle | sed "s/^.*ndkVersion//; s/'//g"|sed 's/"//g;s/[[:space:]]//g')
+      if [ ! -z $ndk_version ]
+      then
+        yes | sdkmanager --channel=3 --install "ndk;$ndk_version"
+      fi
+
       yes | sdkmanager --update
       popd
     fi

--- a/API-Samples/CMakeLists.txt
+++ b/API-Samples/CMakeLists.txt
@@ -98,7 +98,9 @@ function(sampleWithSingleFile)
             # Add validation layer settings.
             set (SAMPLE_WITH_TOOLS create_debug_report_callback enable_validation_with_callback)
             if (";${SAMPLE_WITH_TOOLS};" MATCHES ";${SAMPLE_NAME};")
-                set (VALIDATIONLAYER_PACKING "sourceSets.main.jniLibs.srcDirs file(ndkDir).absolutePath +\n\t\t\t\t'/sources/third_party/vulkan/src/build-android/jniLibs'")
+		    set (VALIDATIONLAYER_PACKING "sourceSets.main.jniLibs.srcDirs ")
+		    string(APPEND VALIDATIONLAYER_PACKING "file(android.ndkDirectory.path).absolutePath +\n")
+		    string(APPEND VALIDATIONLAYER_PACKING "\t\t\t\t'/sources/third_party/vulkan/src/build-android/jniLibs'")
             endif()
 
             # Cook template files.

--- a/API-Samples/android/build.gradle
+++ b/API-Samples/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/API-Samples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/API-Samples/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/API-Samples/android/project_template/build.gradle
+++ b/API-Samples/android/project_template/build.gradle
@@ -14,15 +14,16 @@
 
 apply plugin: 'com.android.application'
 
-def ndkDir=android.ndkDirectory.path
 def stlType = 'c++_static'
 
 android {
-    compileSdkVersion  26
+    compileSdkVersion  30
+    buildToolsVersion  '30.0.0'
+    ndkVersion '21.3.6528147'
 
     defaultConfig {
         applicationId '@PACKAGE_NAME@'
-        minSdkVersion    24 // Official vulkan support starts in version 24
+        minSdkVersion    24 // Official vulkan support starts from API level 24
         targetSdkVersion 26
         versionCode  1
         versionName '0.0.1'
@@ -45,8 +46,6 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'),
-                    'proguard-rules.pro'
         }
     }
     @ASSET_DIR@


### PR DESCRIPTION
A few of things: 
1. although prompted by https://github.com/LunarG/VulkanSamples/issues/298, this PR is NOT a fix, we like to keep the gradle version tied with android gradle plugin version 4.0.0 -- Gradle 6.1.1, we know this was tested and less surprises
2. Fixed NDK version in build.gradle to the lastest one NOW: "21.3.6528147". CI needs to install this version of NDK. If NDK version is not specified, a [default built-in ndk version](https://github.com/android/ndk-samples/wiki/Configure-NDK-Path#the-default-ndk-version) will be requested and you need to manually install it.
3. current way getting [ndkDir](https://github.com/LunarG/VulkanSamples/blob/master/API-Samples/android/project_template/build.gradle#L17) does not work with Android Studio /Android Gradle Plugin 4.0.0, and fixed in this PR. this one probably is the only one that matters


