### PR TITLE
Add a flush at the end of the log function

### DIFF
--- a/Sample-Programs/Hologram/Shell.cpp
+++ b/Sample-Programs/Hologram/Shell.cpp
@@ -40,6 +40,7 @@ Shell::Shell(Game &game)
 void Shell::log(LogPriority priority, const char *msg) const {
     std::ostream &st = (priority >= LOG_ERR) ? std::cerr : std::cout;
     st << msg << "\n";
+    fflush(stdout);
 }
 
 void Shell::init_vk() {


### PR DESCRIPTION
Add a flush at the end of the log function so that the output does not gets buffered when redirected.